### PR TITLE
add supply order methods

### DIFF
--- a/ozon/common.go
+++ b/ozon/common.go
@@ -120,3 +120,58 @@ const (
 	BrandDimension     GetAnalyticsDataDimension = "brand"
 	ModelIDDimension   GetAnalyticsDataDimension = "modelID"
 )
+
+type SupplyRequestState string
+
+const (
+	// request draft. Only for supplies via vDC
+	Draft SupplyRequestState = "DRAFT"
+
+	// selecting supply options. Only for supplies via vDC
+	SupplyVariantsArranging SupplyRequestState = "SUPPLY_VARIANTS_ARRANGING"
+
+	// no supply options, the request is archived. Only for supplies via vDC
+	HasNoSupplyVariantsArchive SupplyRequestState = "HAS_NO_SUPPLY_VARIANTS_ARCHIVE"
+
+	// no supply options. Only for supplies via vDC
+	HasNoSupplyVariantsNew SupplyRequestState = "HAS_NO_SUPPLY_VARIANTS_NEW"
+
+	// supply being approved. Only for supplies via vDC
+	SupplyVariantsConfirmation SupplyRequestState = "SUPPLY_VARIANTS_CONFIRMATION"
+
+	// time reservation
+	TimeslotBooking SupplyRequestState = "TIMESLOT_BOOKING"
+
+	// filling in the data
+	DATA_FILLING SupplyRequestState = "DATA_FILLING"
+
+	// ready for shipment
+	ReadyToSupply SupplyRequestState = "READY_TO_SUPPLY"
+
+	// accepted at the shipping point
+	AcceptedAtSupplyWarehouse SupplyRequestState = "ACCEPTED_AT_SUPPLY_WAREHOUSE"
+
+	// on the way
+	InTransit SupplyRequestState = "IN_TRANSIT"
+
+	// acceptance at the warehouse
+	AcceptanceAtStorageWarehouse SupplyRequestState = "ACCEPTANCE_AT_STORAGE_WAREHOUSE"
+
+	// acts being approved
+	ReportsConfirmationAwaiting SupplyRequestState = "REPORTS_CONFIRMATION_AWAITING"
+
+	// dispute
+	ReportRejected SupplyRequestState = "REPORT_REJECTED"
+
+	// completed
+	Completed SupplyRequestState = "COMPLETED"
+
+	// refused acceptance
+	RejectedAtSupplyWarehouse SupplyRequestState = "REJECTED_AT_SUPPLY_WAREHOUSE"
+
+	// cancelled
+	Cancelled SupplyRequestState = "CANCELLED"
+
+	// overdue
+	Overdue SupplyRequestState = "OVERDUE"
+)

--- a/ozon/fbo_test.go
+++ b/ozon/fbo_test.go
@@ -277,3 +277,208 @@ func TestGetShipmentDetails(t *testing.T) {
 		}
 	}
 }
+
+func TestListSupplyRequests(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		statusCode int
+		headers    map[string]string
+		params     *ListSupplyRequestsParams
+		response   string
+	}{
+		// Test Ok
+		{
+			http.StatusOK,
+			map[string]string{"Client-Id": "my-client-id", "Api-Key": "my-api-key"},
+			&ListSupplyRequestsParams{
+				Page:     0,
+				PageSize: 0,
+				States:   []SupplyRequestState{AcceptanceAtStorageWarehouse},
+			},
+			`{
+				"has_next": true,
+				"supply_orders": [
+				  {
+					"created_at": "string",
+					"local_timeslot": {
+					  "from": "string",
+					  "to": "string"
+					},
+					"preferred_supply_date_from": "string",
+					"preferred_supply_date_to": "string",
+					"state": "string",
+					"supply_order_id": 0,
+					"supply_order_number": "string",
+					"supply_warehouse": {
+					  "address": "string",
+					  "name": "string",
+					  "warehouse_id": 0
+					},
+					"time_left_to_prepare_supply": 0,
+					"time_left_to_select_supply_variant": 0,
+					"total_items_count": 0,
+					"total_quantity": 0
+				  }
+				],
+				"total_supply_orders_count": 0
+			}`,
+		},
+		// Test No Client-Id or Api-Key
+		{
+			http.StatusUnauthorized,
+			map[string]string{},
+			&ListSupplyRequestsParams{},
+			`{
+				"code": 16,
+				"message": "Client-Id and Api-Key headers are required"
+			}`,
+		},
+	}
+
+	for _, test := range tests {
+		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
+
+		resp, err := c.FBO().ListSupplyRequests(test.params)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if resp.StatusCode != test.statusCode {
+			t.Errorf("got wrong status code: got: %d, expected: %d", resp.StatusCode, test.statusCode)
+		}
+	}
+}
+
+func TestGetSupplyRequestInfo(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		statusCode int
+		headers    map[string]string
+		params     *GetSupplyRequestInfoParams
+		response   string
+	}{
+		// Test Ok
+		{
+			http.StatusOK,
+			map[string]string{"Client-Id": "my-client-id", "Api-Key": "my-api-key"},
+			&GetSupplyRequestInfoParams{
+				SupplyOrderId: 0,
+			},
+			`{
+				"created_at": "string",
+				"local_timeslot": {
+				  "from": "string",
+				  "to": "string"
+				},
+				"preferred_supply_date_from": "string",
+				"preferred_supply_date_to": "string",
+				"seller_warehouse": {
+				  "address": "string",
+				  "name": "string",
+				  "warehouse_id": 0
+				},
+				"state": "string",
+				"supply_order_id": 0,
+				"supply_order_number": "string",
+				"supply_warehouse": {
+				  "address": "string",
+				  "name": "string",
+				  "warehouse_id": 0
+				},
+				"time_left_to_prepare_supply": 0,
+				"time_left_to_select_supply_variant": 0,
+				"total_items_count": 0,
+				"total_quantity": 0,
+				"vehicle_info": {
+				  "driver_name": "string",
+				  "driver_phone": "string",
+				  "vehicle_model": "string",
+				  "vehicle_number": "string"
+				}
+			}`,
+		},
+		// Test No Client-Id or Api-Key
+		{
+			http.StatusUnauthorized,
+			map[string]string{},
+			&GetSupplyRequestInfoParams{},
+			`{
+				"code": 16,
+				"message": "Client-Id and Api-Key headers are required"
+			}`,
+		},
+	}
+
+	for _, test := range tests {
+		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
+
+		resp, err := c.FBO().GetSupplyRequestInfo(test.params)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if resp.StatusCode != test.statusCode {
+			t.Errorf("got wrong status code: got: %d, expected: %d", resp.StatusCode, test.statusCode)
+		}
+	}
+}
+
+func TestListProductsInSupplyRequest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		statusCode int
+		headers    map[string]string
+		params     *ListProductsInSupplyRequestParams
+		response   string
+	}{
+		// Test Ok
+		{
+			http.StatusOK,
+			map[string]string{"Client-Id": "my-client-id", "Api-Key": "my-api-key"},
+			&ListProductsInSupplyRequestParams{
+				Page:          0,
+				PageSize:      0,
+				SupplyOrderId: 0,
+			},
+			`{
+				"has_next": true,
+				"items": [
+				  {
+					"icon_path": "string",
+					"name": "string",
+					"offer_id": "string",
+					"quantity": 0,
+					"sku": 0
+				  }
+				],
+				"total_items_count": 0
+			}`,
+		},
+		// Test No Client-Id or Api-Key
+		{
+			http.StatusUnauthorized,
+			map[string]string{},
+			&ListProductsInSupplyRequestParams{},
+			`{
+				"code": 16,
+				"message": "Client-Id and Api-Key headers are required"
+			}`,
+		},
+	}
+
+	for _, test := range tests {
+		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
+
+		resp, err := c.FBO().ListProductsInSupplyRequest(test.params)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if resp.StatusCode != test.statusCode {
+			t.Errorf("got wrong status code: got: %d, expected: %d", resp.StatusCode, test.statusCode)
+		}
+	}
+}


### PR DESCRIPTION
[April 10, 2023](https://docs.ozon.ru/api/seller/en/#section/April-10-2023)
Add methods:
- [/v1/supply-order/list](https://docs.ozon.ru/api/seller/#operation/SupplyOrderAPI_GetSupplyOrdersList) Added a method for getting a list of supply requests to the Ozon warehouse
- [/v1/supply-order/get](https://docs.ozon.ru/api/seller/#operation/SupplyOrderAPI_GetSupplyOrder) Added a method for getting information on a supply request.
- [/v1/supply-order/items](https://docs.ozon.ru/api/seller/#operation/SupplyOrderAPI_GetSupplyOrderItems) Added a method for getting a list of products in a supply request.