### PR TITLE
added new status to getting act list filter, updated descriptions, changed test according to examples

### DIFF
--- a/ozon/common.go
+++ b/ozon/common.go
@@ -377,3 +377,61 @@ const (
 	StrategyCreated          StrategyUpdateType = "strategyCreated"
 	StrategyItemsListChanged StrategyUpdateType = "strategyItemsListChanged"
 )
+
+type ShipmentCertificateFilterStatus string
+
+const (
+	// new
+	ShitmentCertificateFilterNew ShipmentCertificateFilterStatus = "new"
+
+	// retry creation
+	ShitmentCertificateFilterAwaitingRetry ShipmentCertificateFilterStatus = "awaiting-retry"
+
+	// is being packaged
+	ShitmentCertificateFilterInProcess ShipmentCertificateFilterStatus = "in_process"
+
+	// created
+	ShitmentCertificateFilterSuccess ShipmentCertificateFilterStatus = "success"
+
+	// creation error
+	ShitmentCertificateFilterError ShipmentCertificateFilterStatus = "error"
+
+	// sent
+	ShitmentCertificateFilterSend ShipmentCertificateFilterStatus = "sent"
+
+	// received
+	ShitmentCertificateFilterReceived ShipmentCertificateFilterStatus = "received"
+
+	// packaged
+	ShitmentCertificateFilterFormed ShipmentCertificateFilterStatus = "formed"
+
+	// canceled
+	ShitmentCertificateFilterCancelled ShipmentCertificateFilterStatus = "cancelled"
+
+	// in the queue for packaging
+	ShitmentCertificateFilterPending ShipmentCertificateFilterStatus = "pending"
+
+	// in the queue for completion
+	ShitmentCertificateFilterCompletionEnqueued ShipmentCertificateFilterStatus = "completion_enqueued"
+
+	// in the process of completion
+	ShitmentCertificateFilterCompletionProcessing ShipmentCertificateFilterStatus = "completion_processing"
+
+	// completion error
+	ShitmentCertificateFilterCompletionFailed ShipmentCertificateFilterStatus = "completion_failed"
+
+	// in the queue for cancellation
+	ShitmentCertificateFilterCancelationEnqueued ShipmentCertificateFilterStatus = "cancelation_enqueued"
+
+	// in the process of cancellation
+	ShitmentCertificateFilterCancelationProcessing ShipmentCertificateFilterStatus = "cancelation_processing"
+
+	// cancellation error
+	ShitmentCertificateFilterCancelationFailed ShipmentCertificateFilterStatus = "cancelation_failed"
+
+	// completed
+	ShitmentCertificateFilterCompleted ShipmentCertificateFilterStatus = "completed"
+
+	// closed
+	ShitmentCertificateFilterClosed ShipmentCertificateFilterStatus = "closed"
+)

--- a/ozon/fbo_test.go
+++ b/ozon/fbo_test.go
@@ -43,8 +43,8 @@ func TestGetFBOShipmentsList(t *testing.T) {
 					"posting_number": "16965409-0014-1",
 					"status": "delivered",
 					"cancel_reason_id": 0,
-					"created_at": "2021-09-01T00:23:45.607Z",
-					"in_process_at": "2021-09-01T00:25:30.120Z",
+					"created_at": "2021-09-01T00:23:45.607000Z",
+					"in_process_at": "2021-09-01T00:25:30.120000Z",
 					"products": [
 					  {
 						"sku": 160249683,

--- a/ozon/fbs.go
+++ b/ozon/fbs.go
@@ -845,13 +845,13 @@ func (c FBS) AddTrackingNumbers(params *AddTrackingNumbersParams) (*AddTrackingN
 
 type ListOfShipmentCertificatesParams struct {
 	// Filter parameters
-	Filter ListOfShipmentCertificates `json:"filter"`
+	Filter ListOfShipmentCertificatesFilter `json:"filter"`
 
 	// Maximum number of certificates in the response
 	Limit int64 `json:"limit"`
 }
 
-type ListOfShipmentCertificates struct {
+type ListOfShipmentCertificatesFilter struct {
 	// Initial date of shipment creation
 	DateFrom string `json:"date_from"`
 
@@ -866,7 +866,7 @@ type ListOfShipmentCertificates struct {
 	IntegrationType string `json:"integration_type"`
 
 	// Freight statuses
-	Status []string `json:"status"`
+	Status []ShipmentCertificateFilterStatus `json:"status"`
 }
 
 type ListOfShipmentCertificatesResponse struct {
@@ -1121,20 +1121,22 @@ type CancelShipmentResponse struct {
 	Result bool `json:"result"`
 }
 
-// Change shipment status to cancelled.
-//
-// If you are using the rFBS scheme, you have the following cancellation reason identifiers (cancel_reason_id) available:
-//   - 352 — product is out of stock;
-//   - 400 — only defective products left;
-//   - 401 — cancellation from arbitration;
-//   - 402 — other reason;
-//   - 665 — the customer did not pick the order;
-//   - 666 — delivery is not available in the region;
-//   - 667 — order was lost by the delivery service.
-//
-// For presumably delivered orders only the last 3 reasons are available.
-//
-// If cancel_reason_id parameter value is 402, fill the cancel_reason_message field
+// Change shipment status to `cancelled`.
+// 
+// If you are using the rFBS scheme, you have the following cancellation reason identifiers (`cancel_reason_id`) available:
+// 
+// 352—product is out of stock ;
+// 400—only defective products left;
+// 401—cancellation from arbitration;
+// 402—other reason;
+// 665—the customer didn't pick the order;
+// 666—delivery isn't available in the region;
+// 667—order was lost by the delivery service.
+// The last 4 reasons are available for shipments in the "Delivering" and "Courier on the way" statuses.
+// 
+// You can't cancel presumably delivered orders.
+// 
+// If `cancel_reason_id` parameter value is 402, fill the `cancel_reason_message` field.
 func (c FBS) CancelShipment(params *CancelShipmentParams) (*CancelShipmentResponse, error) {
 	url := "/v2/posting/fbs/cancel"
 
@@ -1454,10 +1456,10 @@ type RescheduleShipmentDeliveryDateParams struct {
 
 type RescheduleShipmentDeliveryDateTimeslot struct {
 	// Period start date
-	DeliveryDateBegin time.Time `json:"delivery_date_begin"`
+	From time.Time `json:"from"`
 
 	// Period end date
-	DeliveryDateEnd time.Time `json:"delivery_date_end"`
+	To time.Time `json:"to"`
 }
 
 type RescheduleShipmentDeliveryDateResponse struct {
@@ -2013,7 +2015,22 @@ type CancelSendingResponse struct {
 	Result string `json:"result"`
 }
 
-// Use this method if you cannot send some of the products from the shipment
+// Use this method if you cannot send some of the products from the shipment.
+// 
+// If you are using the rFBS scheme, you have the following cancellation reason identifiers (`cancel_reason_id`) available:
+// 
+// 352—product is out of stock;
+// 400—only defective products left;
+// 401—cancellation from arbitration;
+// 402—other reason;
+// 665—the customer did not pick the order;
+// 666—delivery is not available in the region;
+// 667—order was lost by the delivery service.
+// The last 4 reasons are available for shipments in the "Delivering" and "Courier on the way" statuses.
+// 
+// You can't cancel presumably delivered orders.
+// 
+// If `cancel_reason_id` parameter value is 402, fill the `cancel_reason_message` field.
 func (c FBS) CancelSending(params *CancelSendingParams) (*CancelSendingResponse, error) {
 	url := "/v2/posting/fbs/product/cancel"
 

--- a/ozon/fbs_test.go
+++ b/ozon/fbs_test.go
@@ -751,11 +751,11 @@ func TestListOfShipmentCertificates(t *testing.T) {
 			map[string]string{"Client-Id": "my-client-id", "Api-Key": "my-api-key"},
 			&ListOfShipmentCertificatesParams{
 				Limit: 100,
-				Filter: ListOfShipmentCertificates{
+				Filter: ListOfShipmentCertificatesFilter{
 					DateFrom:        "2021-08-04",
 					DateTo:          "2022-08-04",
 					IntegrationType: "ozon",
-					Status:          []string{"delivered"},
+					Status:          []ShipmentCertificateFilterStatus{ShitmentCertificateFilterFormed},
 				},
 			},
 			`{
@@ -1480,8 +1480,8 @@ func TestRescheduleShipmentDeliveryDate(t *testing.T) {
 			&RescheduleShipmentDeliveryDateParams{
 				PostingNumber: "23281294-0063-2",
 				NewTimeslot: RescheduleShipmentDeliveryDateTimeslot{
-					DeliveryDateBegin: core.TimeFromString(t, "2006-01-02T15:04:05Z", "2023-03-03T11:07:00.381Z"),
-					DeliveryDateEnd:   core.TimeFromString(t, "2006-01-02T15:04:05Z", "2023-03-03T11:07:00.381Z"),
+					From: core.TimeFromString(t, "2006-01-02T15:04:05Z", "2023-03-25T08:51:56.932Z"),
+					To:   core.TimeFromString(t, "2006-01-02T15:04:05Z", "2023-03-25T08:51:56.932Z"),
 				},
 			},
 			`{

--- a/ozon/products.go
+++ b/ozon/products.go
@@ -1577,6 +1577,8 @@ func (c Products) ArchiveProduct(params *ArchiveProductParams) (*ArchiveProductR
 	return resp, nil
 }
 
+// Warning: Since June 14, 2023 the method is disabled.
+// 
 // Unarchive product
 func (c Products) UnarchiveProduct(params *ArchiveProductParams) (*ArchiveProductResponse, error) {
 	url := "/v1/product/unarchive"


### PR DESCRIPTION
* statuses for ListOfShipmentCertificatesFilter as enum type
* updated descriptions for methods `CancelSending`, `CancelShipment`
* corrected test for `GetShipmentsList`
* `UnarchiveProduct` is disabled since June 14, 2023