### PR TITLE
Update/july 12 2023

### DIFF
--- a/ozon/fbs.go
+++ b/ozon/fbs.go
@@ -2678,3 +2678,30 @@ func (c FBS) BarcodeFromProductShipment(params *BarcodeFromProductShipmentParams
 
 	return resp, nil
 }
+
+type BarcodeValueFromProductShipmentParams struct {
+	// Freight identifier
+	Id int64 `json:"id"`
+}
+
+type BarcodeValueFromProductShipmentResponse struct {
+	core.CommonResponse
+
+	// Barcode in text format
+	Result string `json:"result"`
+}
+
+// Use this method to get the barcode from the /v2/posting/fbs/act/get-barcode response in text format.
+func (c FBS) BarcodeValueFromProductShipment(params *BarcodeValueFromProductShipmentParams) (*BarcodeValueFromProductShipmentResponse, error) {
+	url := "/v2/posting/fbs/act/get-barcode/text"
+
+	resp := &BarcodeValueFromProductShipmentResponse{}
+
+	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	if err != nil {
+		return nil, err
+	}
+	response.CopyCommonResponse(&resp.CommonResponse)
+
+	return resp, nil
+}

--- a/ozon/fbs.go
+++ b/ozon/fbs.go
@@ -2645,3 +2645,36 @@ func (c FBS) ETGBCustomsDeclarations(params *ETGBCustomsDeclarationsParams) (*ET
 
 	return resp, nil
 }
+
+type BarcodeFromProductShipmentParams struct {
+	// Freight identifier
+	Id int64 `json:"id"`
+}
+
+type BarcodeFromProductShipmentResponse struct {
+	core.CommonResponse
+
+	// Link to barcode image
+	Content string `json:"content"`
+
+	// File name
+	Name string `json:"name"`
+
+	// File type
+	Type string `json:"type"`
+}
+
+// Method for getting a barcode to show at a pick-up point or sorting center during the shipment
+func (c FBS) BarcodeFromProductShipment(params *BarcodeFromProductShipmentParams) (*BarcodeFromProductShipmentResponse, error) {
+	url := "/v2/posting/fbs/act/get-barcode"
+
+	resp := &BarcodeFromProductShipmentResponse{}
+
+	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	if err != nil {
+		return nil, err
+	}
+	response.CopyCommonResponse(&resp.CommonResponse)
+
+	return resp, nil
+}

--- a/ozon/fbs_test.go
+++ b/ozon/fbs_test.go
@@ -2586,3 +2586,55 @@ func TestBarcodeFromProductShipment(t *testing.T) {
 		}
 	}
 }
+
+func TestBarcodeValueFromProductShipment(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		statusCode int
+		headers    map[string]string
+		params     *BarcodeValueFromProductShipmentParams
+		response   string
+	}{
+		// Test Ok
+		{
+			http.StatusOK,
+			map[string]string{"Client-Id": "my-client-id", "Api-Key": "my-api-key"},
+			&BarcodeValueFromProductShipmentParams{
+				Id: 295662811,
+			},
+			`{
+				"result": "%303%24276481394"
+			}`,
+		},
+		// Test No Client-Id or Api-Key
+		{
+			http.StatusUnauthorized,
+			map[string]string{},
+			&BarcodeValueFromProductShipmentParams{},
+			`{
+				"code": 16,
+				"message": "Client-Id and Api-Key headers are required"
+			}`,
+		},
+	}
+
+	for _, test := range tests {
+		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
+
+		resp, err := c.FBS().BarcodeValueFromProductShipment(test.params)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if resp.StatusCode != test.statusCode {
+			t.Errorf("got wrong status code: got: %d, expected: %d", resp.StatusCode, test.statusCode)
+		}
+
+		if resp.StatusCode == http.StatusOK {
+			if resp.Result == "" {
+				t.Errorf("result cannot be empty")
+			}
+		}
+	}
+}


### PR DESCRIPTION
**NEW METHOD** Added a method for getting a barcode used during product shipment
**NEW METHOD** Added a method for getting a barcode from the [/v2/posting/fbs/act/get-barcode](https://docs.ozon.ru/api/seller/en/#operation/PostingAPI_PostingFBSGetBarcode) response in text format.
Full info: https://docs.ozon.ru/api/seller/en/#section/July-12-2023