### PR TITLE
Configure HttpClient, added context parameter to all methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ func main() {
 	client := ozon.NewClient("my-client-id", "my-api-key")
 
 	// Send request with parameters
-	resp, err := client.Products().GetProductDetails(&ozon.GetProductDetailsParams{
+	ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+resp, err := client.Products().GetProductDetails(&ozon.GetProductDetailsParams{
 		ProductId: 123456789,
 	})
 	if err != nil || resp.StatusCode != http.StatusOK {

--- a/client_test.go
+++ b/client_test.go
@@ -1,8 +1,14 @@
 package core
 
 import (
+	"context"
 	"net/http"
 	"testing"
+	"time"
+)
+
+const (
+	testTimeout = 5 * time.Second
 )
 
 type TestRequestRequest struct {
@@ -55,7 +61,8 @@ func TestRequest(t *testing.T) {
 		c := NewMockClient(NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
 		respStruct := &TestRequestResponse{}
-		resp, err := c.Request(http.MethodPost, "/", test.params, respStruct, nil)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Request(ctx, http.MethodPost, "/", test.params, respStruct, nil)
 
 		if err != nil {
 			t.Error(err)

--- a/ozon/analytics.go
+++ b/ozon/analytics.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -94,12 +95,12 @@ type GetAnalyticsDataResultDimension struct {
 }
 
 // Specify the period and metrics that are required. The response will contain analytical data grouped by the `dimensions` parameter.
-func (c Analytics) GetAnalyticsData(params *GetAnalyticsDataParams) (*GetAnalyticsDataResponse, error) {
+func (c Analytics) GetAnalyticsData(ctx context.Context, params *GetAnalyticsDataParams) (*GetAnalyticsDataResponse, error) {
 	url := "/v1/analytics/data"
 
 	resp := &GetAnalyticsDataResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -157,12 +158,12 @@ type GetStocksOnWarehousesResultRow struct {
 }
 
 // Report on stocks and products movement at Ozon warehouses
-func (c Analytics) GetStocksOnWarehouses(params *GetStocksOnWarehousesParams) (*GetStocksOnWarehousesResponse, error) {
+func (c Analytics) GetStocksOnWarehouses(ctx context.Context, params *GetStocksOnWarehousesParams) (*GetStocksOnWarehousesResponse, error) {
 	url := "/v2/analytics/stock_on_warehouses"
 
 	resp := &GetStocksOnWarehousesResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/ozon/analytics_test.go
+++ b/ozon/analytics_test.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -59,7 +60,8 @@ func TestGetAnalyticsData(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Analytics().GetAnalyticsData(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Analytics().GetAnalyticsData(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -119,7 +121,8 @@ func TestGetStocksOnWarehouses(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Analytics().GetStocksOnWarehouses(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Analytics().GetStocksOnWarehouses(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}

--- a/ozon/brands.go
+++ b/ozon/brands.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 
 	core "github.com/diphantxm/ozon-api-client"
@@ -44,12 +45,12 @@ type ListCertifiedBrandsResultCertificate struct {
 }
 
 // List of certified brands
-func (c Brands) List(params *ListCertifiedBrandsParams) (*ListCertifiedBrandsResponse, error) {
+func (c Brands) List(ctx context.Context, params *ListCertifiedBrandsParams) (*ListCertifiedBrandsResponse, error) {
 	url := "/v1/brand/company-certification/list"
 
 	resp := &ListCertifiedBrandsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/ozon/brands_test.go
+++ b/ozon/brands_test.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -52,7 +53,8 @@ func TestListCertifiedBrands(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Brands().List(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Brands().List(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}

--- a/ozon/cancellations.go
+++ b/ozon/cancellations.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -81,12 +82,12 @@ type CancellationInfoState struct {
 }
 
 // Method for getting information about a rFBS cancellation request
-func (c Cancellations) GetInfo(params *GetCancellationInfoParams) (*GetCancellationInfoResponse, error) {
+func (c Cancellations) GetInfo(ctx context.Context, params *GetCancellationInfoParams) (*GetCancellationInfoResponse, error) {
 	url := "/v1/delivery-method/list"
 
 	resp := &GetCancellationInfoResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -153,12 +154,12 @@ type ListCancellationResponseCounters struct {
 }
 
 // Method for getting a list of rFBS cancellation requests
-func (c Cancellations) List(params *ListCancellationsParams) (*ListCancellationsResponse, error) {
+func (c Cancellations) List(ctx context.Context, params *ListCancellationsParams) (*ListCancellationsResponse, error) {
 	url := "/v1/conditional-cancellation/list"
 
 	resp := &ListCancellationsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -181,12 +182,12 @@ type ApproveRejectCancellationsResponse struct {
 
 // The method allows to approve an rFBS cancellation request in the ON_APPROVAL status.
 // The order will be canceled and the money will be returned to the customer
-func (c Cancellations) Approve(params *ApproveRejectCancellationsParams) (*ApproveRejectCancellationsResponse, error) {
+func (c Cancellations) Approve(ctx context.Context, params *ApproveRejectCancellationsParams) (*ApproveRejectCancellationsResponse, error) {
 	url := "/v1/conditional-cancellation/approve"
 
 	resp := &ApproveRejectCancellationsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -198,12 +199,12 @@ func (c Cancellations) Approve(params *ApproveRejectCancellationsParams) (*Appro
 // The method allows to reject an rFBS cancellation request in the ON_APPROVAL status. Explain your decision in the comment parameter.
 //
 // The order will remain in the same status and must be delivered to the customer
-func (c Cancellations) Reject(params *ApproveRejectCancellationsParams) (*ApproveRejectCancellationsResponse, error) {
+func (c Cancellations) Reject(ctx context.Context, params *ApproveRejectCancellationsParams) (*ApproveRejectCancellationsResponse, error) {
 	url := "/v1/conditional-cancellation/reject"
 
 	resp := &ApproveRejectCancellationsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/ozon/cancellations_test.go
+++ b/ozon/cancellations_test.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -62,7 +63,8 @@ func TestGetCancellationInfo(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Cancellations().GetInfo(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Cancellations().GetInfo(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -171,7 +173,8 @@ func TestListCancellations(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Cancellations().List(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Cancellations().List(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -215,7 +218,8 @@ func TestApproveCancellations(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Cancellations().Approve(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Cancellations().Approve(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -259,7 +263,8 @@ func TestRejectCancellations(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Cancellations().Reject(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Cancellations().Reject(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}

--- a/ozon/categories.go
+++ b/ozon/categories.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 
 	core "github.com/diphantxm/ozon-api-client"
@@ -40,12 +41,12 @@ type GetProductTreeResult struct {
 // New products can be created in the last level categories only.
 // This means that you need to match these particular categories with the categories of your site.
 // It is not possible to create categories by user request
-func (c Categories) Tree(params *GetProductTreeParams) (*GetProductTreeResponse, error) {
+func (c Categories) Tree(ctx context.Context, params *GetProductTreeParams) (*GetProductTreeResponse, error) {
 	url := "/v2/category/tree"
 
 	resp := &GetProductTreeResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -134,12 +135,12 @@ type GetCategoryAttributesResultAttribute struct {
 // You can check whether the attribute has a nested directory by the `dictionary_id` parameter.
 // The 0 value means there is no directory. If the value is different, then there are directories.
 // You can get them using the `/v2/category/attribute/values` method
-func (c Categories) Attributes(params *GetCategoryAttributesParams) (*GetCategoryAttributesResponse, error) {
+func (c Categories) Attributes(ctx context.Context, params *GetCategoryAttributesParams) (*GetCategoryAttributesResponse, error) {
 	url := "/v3/category/attribute"
 
 	resp := &GetCategoryAttributesResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -187,12 +188,12 @@ type GetAttributeDictionaryResult struct {
 
 // You can use the `/v3/category/attribute` method to check if an attribute has a nested directory.
 // If there are directories, get them using this method
-func (c Categories) AttributesDictionary(params *GetAttributeDictionaryParams) (*GetAttributeDictionaryResponse, error) {
+func (c Categories) AttributesDictionary(ctx context.Context, params *GetAttributeDictionaryParams) (*GetAttributeDictionaryResponse, error) {
 	url := "/v2/category/attribute/values"
 
 	resp := &GetAttributeDictionaryResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/ozon/categories_test.go
+++ b/ozon/categories_test.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -48,7 +49,8 @@ func TestGetProductTree(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Categories().Tree(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Categories().Tree(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -119,7 +121,8 @@ func TestGetCategoryAttributes(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Categories().Attributes(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Categories().Attributes(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -199,7 +202,8 @@ func TestGetAttributeDictionary(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Categories().AttributesDictionary(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Categories().AttributesDictionary(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}

--- a/ozon/certificates.go
+++ b/ozon/certificates.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -43,12 +44,12 @@ type ListOfAccordanceTypesResultHazard struct {
 }
 
 // List of accordance types (version 2)
-func (c Certificates) ListOfAccordanceTypes() (*ListOfAccordanceTypesResponse, error) {
+func (c Certificates) ListOfAccordanceTypes(ctx context.Context) (*ListOfAccordanceTypesResponse, error) {
 	url := "/v2/product/certificate/accordance-types/list"
 
 	resp := &ListOfAccordanceTypesResponse{}
 
-	response, err := c.client.Request(http.MethodGet, url, nil, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodGet, url, nil, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -73,12 +74,12 @@ type DirectoryOfDocumentTypesResult struct {
 }
 
 // Directory of document types
-func (c Certificates) DirectoryOfDocumentTypes() (*DirectoryOfDocumentTypesResponse, error) {
+func (c Certificates) DirectoryOfDocumentTypes(ctx context.Context) (*DirectoryOfDocumentTypesResponse, error) {
 	url := "/v1/product/certificate/types"
 
 	resp := &DirectoryOfDocumentTypesResponse{}
 
-	response, err := c.client.Request(http.MethodGet, url, nil, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodGet, url, nil, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -119,12 +120,12 @@ type ListOfCertifiedCategoriesResultCert struct {
 }
 
 // List of certified categories
-func (c Certificates) ListOfCertifiedCategories(params *ListOfCertifiedCategoriesParams) (*ListOfCertifiedCategoriesResponse, error) {
+func (c Certificates) ListOfCertifiedCategories(ctx context.Context, params *ListOfCertifiedCategoriesParams) (*ListOfCertifiedCategoriesResponse, error) {
 	url := "/v1/product/certificate/types"
 
 	resp := &ListOfCertifiedCategoriesResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -149,12 +150,12 @@ type LinkCertificateToProductResponse struct {
 }
 
 // Link the certificate to the product
-func (c Certificates) LinkToProduct(params *LinkCertificateToProductParams) (*LinkCertificateToProductResponse, error) {
+func (c Certificates) LinkToProduct(ctx context.Context, params *LinkCertificateToProductParams) (*LinkCertificateToProductResponse, error) {
 	url := "/v1/product/certificate/bind"
 
 	resp := &LinkCertificateToProductResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -186,12 +187,12 @@ type DeleteCertificateResult struct {
 }
 
 // Delete certificate
-func (c Certificates) Delete(params *DeleteCertificateParams) (*DeleteCertificateResponse, error) {
+func (c Certificates) Delete(ctx context.Context, params *DeleteCertificateParams) (*DeleteCertificateResponse, error) {
 	url := "/v1/product/certificate/delete"
 
 	resp := &DeleteCertificateResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -248,12 +249,12 @@ type GetCertificateInfoResult struct {
 }
 
 // Certificate information
-func (c Certificates) GetInfo(params *GetCertificateInfoParams) (*GetCertificateInfoResponse, error) {
+func (c Certificates) GetInfo(ctx context.Context, params *GetCertificateInfoParams) (*GetCertificateInfoResponse, error) {
 	url := "/v1/product/certificate/info"
 
 	resp := &GetCertificateInfoResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -331,12 +332,12 @@ type ListCertificatesResultCert struct {
 }
 
 // Certificates list
-func (c Certificates) List(params *ListCertificatesParams) (*ListCertificatesResponse, error) {
+func (c Certificates) List(ctx context.Context, params *ListCertificatesParams) (*ListCertificatesResponse, error) {
 	url := "/v1/product/certificate/list"
 
 	resp := &ListCertificatesResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -360,12 +361,12 @@ type ProductStatusesResult struct {
 	Name string `json:"name"`
 }
 
-func (c Certificates) ProductStatuses() (*ProductStatusesResponse, error) {
+func (c Certificates) ProductStatuses(ctx context.Context) (*ProductStatusesResponse, error) {
 	url := "/v1/product/certificate/list"
 
 	resp := &ProductStatusesResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, nil, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, nil, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -410,12 +411,12 @@ type ListProductsForCertificateResult struct {
 }
 
 // A method for getting a list of possible statuses of products when binding them to a certificate
-func (c Certificates) ListProductsForCertificate(params *ListProductsForCertificateParams) (*ListProductsForCertificateResponse, error) {
+func (c Certificates) ListProductsForCertificate(ctx context.Context, params *ListProductsForCertificateParams) (*ListProductsForCertificateResponse, error) {
 	url := "/v1/product/certificate/products/list"
 
 	resp := &ListProductsForCertificateResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -453,12 +454,12 @@ type UnlinkFromProductResult struct {
 }
 
 // Unbind products from a certificate
-func (c Certificates) UnlinkFromProduct(params *UnlinkFromProductParams) (*UnlinkFromProductResponse, error) {
+func (c Certificates) UnlinkFromProduct(ctx context.Context, params *UnlinkFromProductParams) (*UnlinkFromProductResponse, error) {
 	url := "/v1/product/certificate/unbind"
 
 	resp := &UnlinkFromProductResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -483,12 +484,12 @@ type PossibleRejectReasonsResult struct {
 }
 
 // Possible certificate rejection reasons
-func (c Certificates) PossibleRejectReasons() (*PossibleRejectReasonsResponse, error) {
+func (c Certificates) PossibleRejectReasons(ctx context.Context) (*PossibleRejectReasonsResponse, error) {
 	url := "/v1/product/certificate/rejection_reasons/list"
 
 	resp := &PossibleRejectReasonsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, nil, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, nil, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -512,12 +513,12 @@ type PossibleStatusesResult struct {
 	Name string `json:"name"`
 }
 
-func (c Certificates) PossibleStatuses() (*PossibleStatusesResponse, error) {
+func (c Certificates) PossibleStatuses(ctx context.Context) (*PossibleStatusesResponse, error) {
 	url := "/v1/product/certificate/status/list"
 
 	resp := &PossibleStatusesResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, nil, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, nil, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -556,12 +557,12 @@ type AddCertificatesForProductsResponse struct {
 }
 
 // Adding certificates for products
-func (c Certificates) AddForProducts(params *AddCertificatesForProductsParams) (*AddCertificatesForProductsResponse, error) {
+func (c Certificates) AddForProducts(ctx context.Context, params *AddCertificatesForProductsParams) (*AddCertificatesForProductsResponse, error) {
 	url := "/v1/product/certificate/create"
 
 	resp := &AddCertificatesForProductsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, nil, resp, map[string]string{
+	response, err := c.client.Request(ctx, http.MethodPost, url, nil, resp, map[string]string{
 		"Content-Type": "multipart/form-data",
 	})
 	if err != nil {

--- a/ozon/certificates_test.go
+++ b/ozon/certificates_test.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 	"testing"
 	"time"
@@ -51,7 +52,8 @@ func TestListOfAccordanceTypes(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Certificates().ListOfAccordanceTypes()
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Certificates().ListOfAccordanceTypes(ctx)
 		if err != nil {
 			t.Error(err)
 		}
@@ -113,7 +115,8 @@ func TestDirectoryOfDocumentTypes(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Certificates().DirectoryOfDocumentTypes()
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Certificates().DirectoryOfDocumentTypes(ctx)
 		if err != nil {
 			t.Error(err)
 		}
@@ -168,7 +171,8 @@ func TestListOfCertifiedCategories(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Certificates().ListOfCertifiedCategories(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Certificates().ListOfCertifiedCategories(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -215,7 +219,8 @@ func TestLinkCertificateToProduct(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Certificates().LinkToProduct(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Certificates().LinkToProduct(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -264,7 +269,8 @@ func TestDeleteCertificate(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Certificates().Delete(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Certificates().Delete(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -322,7 +328,8 @@ func TestGetCertificateInfo(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Certificates().GetInfo(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Certificates().GetInfo(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -395,7 +402,8 @@ func TestListCertificates(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Certificates().List(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Certificates().List(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -441,7 +449,8 @@ func TestProductStatuses(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Certificates().ProductStatuses()
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Certificates().ProductStatuses(ctx)
 		if err != nil {
 			t.Error(err)
 		}
@@ -498,7 +507,8 @@ func TestListProductsForCertificate(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Certificates().ListProductsForCertificate(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Certificates().ListProductsForCertificate(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -551,7 +561,8 @@ func TestUnlinkFromProduct(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Certificates().UnlinkFromProduct(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Certificates().UnlinkFromProduct(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -597,7 +608,8 @@ func TestPossibleRejectReasons(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Certificates().PossibleRejectReasons()
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Certificates().PossibleRejectReasons(ctx)
 		if err != nil {
 			t.Error(err)
 		}
@@ -643,7 +655,8 @@ func TestPossibleStatuses(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Certificates().PossibleStatuses()
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Certificates().PossibleStatuses(ctx)
 		if err != nil {
 			t.Error(err)
 		}
@@ -695,7 +708,8 @@ func TestAddCertificatesForProducts(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Certificates().AddForProducts(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Certificates().AddForProducts(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}

--- a/ozon/chats.go
+++ b/ozon/chats.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -81,12 +82,12 @@ type ListChatsChatData struct {
 }
 
 // Returns information about chats by specified filters
-func (c Chats) List(params *ListChatsParams) (*ListChatsResponse, error) {
+func (c Chats) List(ctx context.Context, params *ListChatsParams) (*ListChatsResponse, error) {
 	url := "/v2/chat/list"
 
 	resp := &ListChatsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -111,12 +112,12 @@ type SendMessageResponse struct {
 }
 
 // Sends a message to an existing chat by its identifier
-func (c Chats) SendMessage(params *SendMessageParams) (*SendMessageResponse, error) {
+func (c Chats) SendMessage(ctx context.Context, params *SendMessageParams) (*SendMessageResponse, error) {
 	url := "/v1/chat/send/message"
 
 	resp := &SendMessageResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -144,12 +145,12 @@ type SendFileResponse struct {
 }
 
 // Sends a file to an existing chat by its identifier
-func (c Chats) SendFile(params *SendFileParams) (*SendFileResponse, error) {
+func (c Chats) SendFile(ctx context.Context, params *SendFileParams) (*SendFileResponse, error) {
 	url := "/v1/chat/send/file"
 
 	resp := &SendFileResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -217,12 +218,12 @@ type ChatHistoryMessageUser struct {
 }
 
 // Chat history
-func (c Chats) History(params *ChatHistoryParams) (*ChatHistoryResponse, error) {
+func (c Chats) History(ctx context.Context, params *ChatHistoryParams) (*ChatHistoryResponse, error) {
 	url := "/v2/chat/history"
 
 	resp := &ChatHistoryResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -337,12 +338,12 @@ type UpdateChatResultUser struct {
 }
 
 // Update chat
-func (c Chats) Update(params *UpdateChatParams) (*UpdateChatResponse, error) {
+func (c Chats) Update(ctx context.Context, params *UpdateChatParams) (*UpdateChatResponse, error) {
 	url := "/v1/chat/updates"
 
 	resp := &UpdateChatResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -369,12 +370,12 @@ type CreateNewChatResult struct {
 }
 
 // Creates a new chat on the shipment with the customer. For example, to clarify the address or the product model
-func (c Chats) Create(params *CreateNewChatParams) (*CreateNewChatResponse, error) {
+func (c Chats) Create(ctx context.Context, params *CreateNewChatParams) (*CreateNewChatResponse, error) {
 	url := "/v1/chat/start"
 
 	resp := &CreateNewChatResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -399,12 +400,12 @@ type MarkAsReadResponse struct {
 }
 
 // A method for marking the selected message and messages before it as read
-func (c Chats) MarkAsRead(params *MarkAsReadParams) (*MarkAsReadResponse, error) {
+func (c Chats) MarkAsRead(ctx context.Context, params *MarkAsReadParams) (*MarkAsReadResponse, error) {
 	url := "/v2/chat/read"
 
 	resp := &MarkAsReadResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/ozon/chats_test.go
+++ b/ozon/chats_test.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -61,7 +62,8 @@ func TestListChats(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Chats().List(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Chats().List(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -119,7 +121,8 @@ func TestSendMessage(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Chats().SendMessage(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Chats().SendMessage(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -167,7 +170,8 @@ func TestSendFile(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Chats().SendFile(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Chats().SendFile(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -230,7 +234,8 @@ func TestChatHistory(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Chats().History(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Chats().History(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -296,7 +301,8 @@ func TestUpdateChat(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Chats().Update(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Chats().Update(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -344,7 +350,8 @@ func TestCreateNewChat(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Chats().Create(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Chats().Create(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -397,7 +404,8 @@ func TestMarkAsRead(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Chats().MarkAsRead(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Chats().MarkAsRead(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}

--- a/ozon/common.go
+++ b/ozon/common.go
@@ -1,5 +1,11 @@
 package ozon
 
+import "time"
+
+const (
+	testTimeout = 5 * time.Second
+)
+
 type Order string
 
 const (

--- a/ozon/fbo.go
+++ b/ozon/fbo.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -165,12 +166,12 @@ type FBOFinancialData struct {
 }
 
 // Returns a list of shipments for a specified period of time. You can additionally filter the shipments by their status
-func (c FBO) GetShipmentsList(params *GetFBOShipmentsListParams) (*GetFBOShipmentsListResponse, error) {
+func (c FBO) GetShipmentsList(ctx context.Context, params *GetFBOShipmentsListParams) (*GetFBOShipmentsListResponse, error) {
 	url := "/v2/posting/fbo/list"
 
 	resp := &GetFBOShipmentsListResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -274,12 +275,12 @@ type GetShipmentDetailsResultAnalyticsData struct {
 }
 
 // Returns information about the shipment by its identifier
-func (c FBO) GetShipmentDetails(params *GetShipmentDetailsParams) (*GetShipmentDetailsResponse, error) {
+func (c FBO) GetShipmentDetails(ctx context.Context, params *GetShipmentDetailsParams) (*GetShipmentDetailsResponse, error) {
 	url := "/v2/posting/fbo/get"
 
 	resp := &GetShipmentDetailsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -374,12 +375,12 @@ type SupplyRequestCommonResponseSupplyWarehouse struct {
 // Method for getting a list of supply requests to the Ozon warehouse.
 // Requests with supply both to a specific warehouse and via a virtual
 // distribution center (vDC) are taken into account
-func (c FBO) ListSupplyRequests(params *ListSupplyRequestsParams) (*ListSupplyRequestsResponse, error) {
+func (c FBO) ListSupplyRequests(ctx context.Context, params *ListSupplyRequestsParams) (*ListSupplyRequestsResponse, error) {
 	url := "/v1/supply-order/list"
 
 	resp := &ListSupplyRequestsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -419,12 +420,12 @@ type GetSupplyRequestInfoVehicle struct {
 // Method for getting detailed information on a supply request.
 // Requests with supply both to a specific warehouse and via a
 // virtual distribution center (vDC) are taken into account
-func (c FBO) GetSupplyRequestInfo(params *GetSupplyRequestInfoParams) (*GetSupplyRequestInfoResponse, error) {
+func (c FBO) GetSupplyRequestInfo(ctx context.Context, params *GetSupplyRequestInfoParams) (*GetSupplyRequestInfoResponse, error) {
 	url := "/v1/supply-order/get"
 
 	resp := &GetSupplyRequestInfoResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -477,12 +478,12 @@ type ListProductsInSupplyRequestItem struct {
 }
 
 // List of products in the sullpy request
-func (c FBO) ListProductsInSupplyRequest(params *ListProductsInSupplyRequestParams) (*ListProductsInSupplyRequestResponse, error) {
+func (c FBO) ListProductsInSupplyRequest(ctx context.Context, params *ListProductsInSupplyRequestParams) (*ListProductsInSupplyRequestResponse, error) {
 	url := "/v1/supply-order/items"
 
 	resp := &ListProductsInSupplyRequestResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -534,12 +535,12 @@ type GetWarehouseWorkloadResultWarehouse struct {
 }
 
 // Method returns a list of active Ozon warehouses with information about their average workload in the nearest future
-func (c FBO) GetWarehouseWorkload() (*GetWarehouseWorkloadResponse, error) {
+func (c FBO) GetWarehouseWorkload(ctx context.Context) (*GetWarehouseWorkloadResponse, error) {
 	url := "/v1/supplier/available_warehouses"
 
 	resp := &GetWarehouseWorkloadResponse{}
 
-	response, err := c.client.Request(http.MethodGet, url, nil, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodGet, url, nil, resp, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/ozon/fbo_test.go
+++ b/ozon/fbo_test.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -133,7 +134,8 @@ func TestGetFBOShipmentsList(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBO().GetShipmentsList(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBO().GetShipmentsList(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -261,7 +263,8 @@ func TestGetShipmentDetails(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBO().GetShipmentDetails(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBO().GetShipmentDetails(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -339,7 +342,8 @@ func TestListSupplyRequests(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBO().ListSupplyRequests(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBO().ListSupplyRequests(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -414,7 +418,8 @@ func TestGetSupplyRequestInfo(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBO().GetSupplyRequestInfo(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBO().GetSupplyRequestInfo(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -472,7 +477,8 @@ func TestListProductsInSupplyRequest(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBO().ListProductsInSupplyRequest(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBO().ListProductsInSupplyRequest(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -530,7 +536,8 @@ func TestGetWarehouseWorkload(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBO().GetWarehouseWorkload()
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBO().GetWarehouseWorkload(ctx)
 		if err != nil {
 			t.Error(err)
 		}

--- a/ozon/fbs.go
+++ b/ozon/fbs.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -494,12 +495,12 @@ type FinancialDataProductPicking struct {
 	Tag string `json:"tag"`
 }
 
-func (c FBS) ListUnprocessedShipments(params *ListUnprocessedShipmentsParams) (*ListUnprocessedShipmentsResponse, error) {
+func (c FBS) ListUnprocessedShipments(ctx context.Context, params *ListUnprocessedShipmentsParams) (*ListUnprocessedShipmentsResponse, error) {
 	url := "/v3/posting/fbs/unfulfilled/list"
 
 	resp := &ListUnprocessedShipmentsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -602,12 +603,12 @@ type GetFBSShipmentsListResult struct {
 // You can filter shipments by their status. The list of available statuses is specified in the description of the filter.status parameter.
 //
 // The true value of the has_next parameter in the response means there is not the entire array of shipments in the response. To get information on the remaining shipments, make a new request with a different offset value.
-func (c FBS) GetFBSShipmentsList(params *GetFBSShipmentsListParams) (*GetFBSShipmentsListResponse, error) {
+func (c FBS) GetFBSShipmentsList(ctx context.Context, params *GetFBSShipmentsListParams) (*GetFBSShipmentsListResponse, error) {
 	url := "/v3/posting/fbs/list"
 
 	resp := &GetFBSShipmentsListResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -673,12 +674,12 @@ type PackOrderAdditionalData struct {
 // Differs from /v2/posting/fbs/ship by the presence of the field `exemplar_info` in the request.
 //
 // If necessary, specify the number of the cargo customs declaration in the gtd parameter. If it is missing, pass the value is_gtd_absent = true
-func (c FBS) PackOrder(params *PackOrderParams) (*PackOrderResponse, error) {
+func (c FBS) PackOrder(ctx context.Context, params *PackOrderParams) (*PackOrderResponse, error) {
 	url := "/v4/posting/fbs/ship"
 
 	resp := &PackOrderResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -743,12 +744,12 @@ type ValidateLabelingCodesResultProduct struct {
 // Method for checking whether labeling codes meet the "Chestny ZNAK" system requirements on length and symbols.
 //
 // If you don't have the customs cargo declaration (CCD) number, you don't have to specify it
-func (c FBS) ValidateLabelingCodes(params *ValidateLabelingCodesParams) (*ValidateLabelingCodesResponse, error) {
+func (c FBS) ValidateLabelingCodes(ctx context.Context, params *ValidateLabelingCodesParams) (*ValidateLabelingCodesResponse, error) {
 	url := "/v4/fbs/posting/product/exemplar/validate"
 
 	resp := &ValidateLabelingCodesResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -845,12 +846,12 @@ type GetShipmentDataByBarcodeResultFinancialData struct {
 }
 
 // Method for getting shipments data by barcode
-func (c FBS) GetShipmentDataByBarcode(params *GetShipmentDataByBarcodeParams) (*GetShipmentDataByBarcodeResponse, error) {
+func (c FBS) GetShipmentDataByBarcode(ctx context.Context, params *GetShipmentDataByBarcodeParams) (*GetShipmentDataByBarcodeResponse, error) {
 	url := "/v2/posting/fbs/get-by-barcode"
 
 	resp := &GetShipmentDataByBarcodeResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1134,12 +1135,12 @@ type FBSProductExemplar struct {
 }
 
 // Method for getting shipment details by identifier
-func (c FBS) GetShipmentDataByIdentifier(params *GetShipmentDataByIdentifierParams) (*GetShipmentDataByIdentifierResponse, error) {
+func (c FBS) GetShipmentDataByIdentifier(ctx context.Context, params *GetShipmentDataByIdentifierParams) (*GetShipmentDataByIdentifierResponse, error) {
 	url := "/v3/posting/fbs/get"
 
 	resp := &GetShipmentDataByIdentifierResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1180,12 +1181,12 @@ type AddTrackingNumbersResponseResult struct {
 }
 
 // Add tracking numbers to shipments
-func (c FBS) AddTrackingNumbers(params *AddTrackingNumbersParams) (*AddTrackingNumbersResponse, error) {
+func (c FBS) AddTrackingNumbers(ctx context.Context, params *AddTrackingNumbersParams) (*AddTrackingNumbersResponse, error) {
 	url := "/v2/fbs/posting/tracking-number/set"
 
 	resp := &AddTrackingNumbersResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1304,12 +1305,12 @@ type FBSAct struct {
 }
 
 // Returns a list of shipment certificates allowing to filter them by time period, status, and integration type
-func (c FBS) ListOfShipmentCertificates(params *ListOfShipmentCertificatesParams) (*ListOfShipmentCertificatesResponse, error) {
+func (c FBS) ListOfShipmentCertificates(ctx context.Context, params *ListOfShipmentCertificatesParams) (*ListOfShipmentCertificatesResponse, error) {
 	url := "/v2/posting/fbs/act/list"
 
 	resp := &ListOfShipmentCertificatesResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1336,12 +1337,12 @@ type SignShipmentCertificateResponse struct {
 }
 
 // Signs shipment certificates electronically via the electronic documents (ED) system of Ozon logistics
-func (c FBS) SignShipmentCertificate(params *SignShipmentCertificateParams) (*SignShipmentCertificateResponse, error) {
+func (c FBS) SignShipmentCertificate(ctx context.Context, params *SignShipmentCertificateParams) (*SignShipmentCertificateResponse, error) {
 	url := "/v2/posting/fbs/digital/act/document-sign"
 
 	resp := &SignShipmentCertificateResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1374,12 +1375,12 @@ type ChangeStatusToResponseResult struct {
 }
 
 // Changes the shipment status to "Delivering" if a third-party delivery service is being used
-func (c FBS) ChangeStatusToDelivering(params *ChangeStatusToParams) (*ChangeStatusToResponse, error) {
+func (c FBS) ChangeStatusToDelivering(ctx context.Context, params *ChangeStatusToParams) (*ChangeStatusToResponse, error) {
 	url := "/v2/fbs/posting/delivering"
 
 	resp := &ChangeStatusToResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1389,12 +1390,12 @@ func (c FBS) ChangeStatusToDelivering(params *ChangeStatusToParams) (*ChangeStat
 }
 
 // Changes the shipment status to "Last mile" if a third-party delivery service is being used
-func (c FBS) ChangeStatusToLastMile(params *ChangeStatusToParams) (*ChangeStatusToResponse, error) {
+func (c FBS) ChangeStatusToLastMile(ctx context.Context, params *ChangeStatusToParams) (*ChangeStatusToResponse, error) {
 	url := "/v2/fbs/posting/last-mile"
 
 	resp := &ChangeStatusToResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1404,12 +1405,12 @@ func (c FBS) ChangeStatusToLastMile(params *ChangeStatusToParams) (*ChangeStatus
 }
 
 // Changes the shipment status to "Delivered" if a third-party delivery service is being used
-func (c FBS) ChangeStatusToDelivered(params *ChangeStatusToParams) (*ChangeStatusToResponse, error) {
+func (c FBS) ChangeStatusToDelivered(ctx context.Context, params *ChangeStatusToParams) (*ChangeStatusToResponse, error) {
 	url := "/v2/fbs/posting/delivered"
 
 	resp := &ChangeStatusToResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1419,12 +1420,12 @@ func (c FBS) ChangeStatusToDelivered(params *ChangeStatusToParams) (*ChangeStatu
 }
 
 // Change shipment status to "Sent by seller". Status is only available to sellers with a first mile selling from abroad
-func (c FBS) ChangeStatusToSendBySeller(params *ChangeStatusToParams) (*ChangeStatusToResponse, error) {
+func (c FBS) ChangeStatusToSendBySeller(ctx context.Context, params *ChangeStatusToParams) (*ChangeStatusToResponse, error) {
 	url := "/v2/fbs/posting/sent-by-seller"
 
 	resp := &ChangeStatusToResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1446,12 +1447,12 @@ type PassShipmentToShippingResponse struct {
 }
 
 // Transfers disputed orders to shipping. The shipment status will change to `awaiting_deliver`
-func (c FBS) PassShipmentToShipping(params *PassShipmentToShippingParams) (*PassShipmentToShippingResponse, error) {
+func (c FBS) PassShipmentToShipping(ctx context.Context, params *PassShipmentToShippingParams) (*PassShipmentToShippingResponse, error) {
 	url := "/v2/posting/fbs/awaiting-delivery"
 
 	resp := &PassShipmentToShippingResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1494,12 +1495,12 @@ type CancelShipmentResponse struct {
 // You can't cancel presumably delivered orders.
 //
 // If `cancel_reason_id` parameter value is 402, fill the `cancel_reason_message` field.
-func (c FBS) CancelShipment(params *CancelShipmentParams) (*CancelShipmentResponse, error) {
+func (c FBS) CancelShipment(ctx context.Context, params *CancelShipmentParams) (*CancelShipmentResponse, error) {
 	url := "/v2/posting/fbs/cancel"
 
 	resp := &CancelShipmentResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1541,12 +1542,12 @@ type CreateActResult struct {
 // Launches the procedure for generating the transfer documents: acceptance and transfer certificate and the waybill.
 //
 // To generate and receive transfer documents, transfer the shipment to the `awaiting_deliver` status
-func (c FBS) CreateAct(params *CreateActParams) (*CreateActResponse, error) {
+func (c FBS) CreateAct(ctx context.Context, params *CreateActParams) (*CreateActResponse, error) {
 	url := "/v2/posting/fbs/act/create"
 
 	resp := &CreateActResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1583,12 +1584,12 @@ type GetLabelingResult struct {
 }
 
 // Method for getting labeling after using the /v1/posting/fbs/package-label/create method
-func (c FBS) GetLabeling(params *GetLabelingParams) (*GetLabelingResponse, error) {
+func (c FBS) GetLabeling(ctx context.Context, params *GetLabelingParams) (*GetLabelingResponse, error) {
 	url := "/v1/posting/fbs/package-label/get"
 
 	resp := &GetLabelingResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, map[string]string{
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, map[string]string{
 		"Content-Type": "application/pdf",
 	})
 	if err != nil {
@@ -1623,12 +1624,12 @@ type PrintLabelingResponse struct {
 // We recommend requesting the label 45-60 seconds after the shipments were packed.
 //
 // The next postings are not ready error means that the label is not ready. Try again later
-func (c FBS) PrintLabeling(params *PrintLabelingParams) (*PrintLabelingResponse, error) {
+func (c FBS) PrintLabeling(ctx context.Context, params *PrintLabelingParams) (*PrintLabelingResponse, error) {
 	url := "/v2/posting/fbs/package-label"
 
 	resp := &PrintLabelingResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, map[string]string{
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, map[string]string{
 		"Content-Type": "application/pdf",
 	})
 	if err != nil {
@@ -1659,12 +1660,12 @@ type CreateTaskForGeneratingLabelResult struct {
 // Method for creating a task for asynchronous labeling generation.
 //
 // To get labels created as a result of the method, use the /v1/posting/fbs/package-label/get method
-func (c FBS) CreateTaskForGeneratingLabel(params *CreateTaskForGeneratingLabelParams) (*CreateTaskForGeneratingLabelResponse, error) {
+func (c FBS) CreateTaskForGeneratingLabel(ctx context.Context, params *CreateTaskForGeneratingLabelParams) (*CreateTaskForGeneratingLabelResponse, error) {
 	url := "/v1/posting/fbs/package-label/create"
 
 	resp := &CreateTaskForGeneratingLabelResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, map[string]string{
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, map[string]string{
 		"Content-Type": "application/pdf",
 	})
 	if err != nil {
@@ -1715,12 +1716,12 @@ type GetDropOffPointRestrictionsResult struct {
 
 // Method for getting dimensions, weight, and other restrictions of the drop-off point by the shipment number.
 // The method is applicable only for the FBS scheme
-func (c FBS) GetDropOffPointRestrictions(params *GetDropOffPointRestrictionsParams) (*GetDropOffPointRestrictionsResponse, error) {
+func (c FBS) GetDropOffPointRestrictions(ctx context.Context, params *GetDropOffPointRestrictionsParams) (*GetDropOffPointRestrictionsResponse, error) {
 	url := "/v1/posting/fbs/restrictions"
 
 	resp := &GetDropOffPointRestrictionsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1766,12 +1767,12 @@ type CheckProductItemsDataResponse struct {
 // For example, you have 10 product items in your system.
 // You have passed them for checking and saving. Then they added another 60 product items to your system.
 // When you pass product items for checking and saving again, pass all of them: both old and newly added
-func (c FBS) CheckproductItemsData(params *CheckProductItemsDataParams) (*CheckProductItemsDataResponse, error) {
+func (c FBS) CheckproductItemsData(ctx context.Context, params *CheckProductItemsDataParams) (*CheckProductItemsDataResponse, error) {
 	url := "/v4/fbs/posting/product/exemplar/set"
 
 	resp := &CheckProductItemsDataResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1803,12 +1804,12 @@ type GetProductItemsCheckStatusesResponse struct {
 
 // Method for getting check statuses of product items that were passed in the `/fbs/posting/product/exemplar/set` method.
 // Also returns data on these product items.
-func (c FBS) GetProductItemsCheckStatuses(params *GetProductItemsCheckStatusesParams) (*GetProductItemsCheckStatusesResponse, error) {
+func (c FBS) GetProductItemsCheckStatuses(ctx context.Context, params *GetProductItemsCheckStatusesParams) (*GetProductItemsCheckStatusesResponse, error) {
 	url := "/v4/fbs/posting/product/exemplar/status"
 
 	resp := &GetProductItemsCheckStatusesResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1841,12 +1842,12 @@ type RescheduleShipmentDeliveryDateResponse struct {
 }
 
 // You can change the delivery date of a shipment up to two times
-func (c FBS) RescheduleShipmentDeliveryDate(params *RescheduleShipmentDeliveryDateParams) (*RescheduleShipmentDeliveryDateResponse, error) {
+func (c FBS) RescheduleShipmentDeliveryDate(ctx context.Context, params *RescheduleShipmentDeliveryDateParams) (*RescheduleShipmentDeliveryDateResponse, error) {
 	url := "/v1/posting/fbs/timeslot/set"
 
 	resp := &RescheduleShipmentDeliveryDateResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1882,12 +1883,12 @@ type DateAvailableForDeliveryScheduleDeliveryInterval struct {
 }
 
 // Method for getting the dates and number of times available for delivery reschedule
-func (c FBS) DateAvailableForDeliverySchedule(params *DateAvailableForDeliveryScheduleParams) (*DateAvailableForDeliveryScheduleResponse, error) {
+func (c FBS) DateAvailableForDeliverySchedule(ctx context.Context, params *DateAvailableForDeliveryScheduleParams) (*DateAvailableForDeliveryScheduleResponse, error) {
 	url := "/v1/posting/fbs/timeslot/change-restrictions"
 
 	resp := &DateAvailableForDeliveryScheduleResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1917,12 +1918,12 @@ type ListManufacturingCountriesResult struct {
 }
 
 // Method for getting a list of available manufacturing countries and their ISO codes
-func (c FBS) ListManufacturingCountries(params *ListManufacturingCountriesParams) (*ListManufacturingCountriesResponse, error) {
+func (c FBS) ListManufacturingCountries(ctx context.Context, params *ListManufacturingCountriesParams) (*ListManufacturingCountriesResponse, error) {
 	url := "/v2/posting/fbs/product/country/list"
 
 	resp := &ListManufacturingCountriesResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1953,12 +1954,12 @@ type SetManufacturingCountryResponse struct {
 }
 
 // The method to set the manufacturing country to the product if it hasn't been specified
-func (c FBS) SetManufacturingCountry(params *SetManufacturingCountryParams) (*SetManufacturingCountryResponse, error) {
+func (c FBS) SetManufacturingCountry(ctx context.Context, params *SetManufacturingCountryParams) (*SetManufacturingCountryResponse, error) {
 	url := "/v2/posting/fbs/product/country/set"
 
 	resp := &SetManufacturingCountryResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2008,12 +2009,12 @@ type PartialPackOrderAdditionalData struct {
 // The primary unassembled shipment will contain some of the products that were not passed to the request.
 //
 // The status of the original shipment will only change when the split shipments status changes
-func (c FBS) PartialPackOrder(params *PartialPackOrderParams) (*PartialPackOrderResponse, error) {
+func (c FBS) PartialPackOrder(ctx context.Context, params *PartialPackOrderParams) (*PartialPackOrderResponse, error) {
 	url := "/v3/posting/fbs/ship/package"
 
 	resp := &PartialPackOrderResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2101,12 +2102,12 @@ type AvailableFreightsListResultError struct {
 }
 
 // Method for getting freights that require printing acceptance and transfer certificates and a waybill
-func (c FBS) AvailableFreightsList(params *AvailableFreightsListParams) (*AvailableFreightsListResponse, error) {
+func (c FBS) AvailableFreightsList(ctx context.Context, params *AvailableFreightsListParams) (*AvailableFreightsListResponse, error) {
 	url := "/v1/posting/carriage-available/list"
 
 	resp := &AvailableFreightsListResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2137,12 +2138,12 @@ type GenerateActResponse struct {
 }
 
 // Get current status of generating digital acceptance and transfer certificate and waybill
-func (c FBS) GenerateAct(params *GenerateActParams) (*GenerateActResponse, error) {
+func (c FBS) GenerateAct(ctx context.Context, params *GenerateActParams) (*GenerateActResponse, error) {
 	url := "/v2/posting/fbs/digital/act/check-status"
 
 	resp := &GenerateActResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2176,12 +2177,12 @@ type GetDigitalActResponse struct {
 }
 
 // Specify the type of a certificate in the doc_type parameter: `act_of_acceptance`, `act_of_mismatch`, `act_of_excess`
-func (c FBS) GetDigitalAct(params *GetDigitalActParams) (*GetDigitalActResponse, error) {
+func (c FBS) GetDigitalAct(ctx context.Context, params *GetDigitalActParams) (*GetDigitalActResponse, error) {
 	url := "/v2/posting/fbs/digital/act/get-pdf"
 
 	resp := &GetDigitalActResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, map[string]string{
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, map[string]string{
 		"Content-Type": "application/json",
 	})
 	if err != nil {
@@ -2211,12 +2212,12 @@ type PackageUnitLabelsResponse struct {
 }
 
 // Method creates package unit labels
-func (c FBS) PackageUnitLabel(params *PackageUnitLabelsParams) (*PackageUnitLabelsResponse, error) {
+func (c FBS) PackageUnitLabel(ctx context.Context, params *PackageUnitLabelsParams) (*PackageUnitLabelsResponse, error) {
 	url := "/v2/posting/fbs/act/get-container-labels"
 
 	resp := &PackageUnitLabelsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, map[string]string{
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, map[string]string{
 		"Content-Type": "application/json",
 	})
 	if err != nil {
@@ -2241,12 +2242,12 @@ type OpenDisputeOverShipmentResponse struct {
 
 // If the shipment has been handed over for delivery, but has not been scanned at the sorting center, you can open a dispute.
 // Opened dispute will put the shipment into the `arbitration` status
-func (c FBS) OpenDisputeOverShipment(params *OpenDisputeOverShipmentParams) (*OpenDisputeOverShipmentResponse, error) {
+func (c FBS) OpenDisputeOverShipment(ctx context.Context, params *OpenDisputeOverShipmentParams) (*OpenDisputeOverShipmentResponse, error) {
 	url := "/v2/posting/fbs/arbitration"
 
 	resp := &OpenDisputeOverShipmentResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2287,12 +2288,12 @@ type ShipmentCancellationReasonsResultReason struct {
 }
 
 // Returns a list of cancellation reasons for particular shipments
-func (c FBS) ShipmentCancellationReasons(params *ShipmentCancellationReasonsParams) (*ShipmentCancellationReasonsResponse, error) {
+func (c FBS) ShipmentCancellationReasons(ctx context.Context, params *ShipmentCancellationReasonsParams) (*ShipmentCancellationReasonsResponse, error) {
 	url := "/v1/posting/fbs/cancel-reason"
 
 	resp := &ShipmentCancellationReasonsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2325,12 +2326,12 @@ type ShipmentsCancellatinoReasonsResult struct {
 }
 
 // Returns a list of cancellation reasons for particular shipments
-func (c FBS) ShipmentsCancellationReasons() (*ShipmentsCancellationReasonsResponse, error) {
+func (c FBS) ShipmentsCancellationReasons(ctx context.Context) (*ShipmentsCancellationReasonsResponse, error) {
 	url := "/v2/posting/fbs/cancel-reason/list"
 
 	resp := &ShipmentsCancellationReasonsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, nil, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, nil, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2363,12 +2364,12 @@ type AddWeightForBulkProductResponse struct {
 }
 
 // Add weight for bulk products in a shipment
-func (c FBS) AddWeightForBulkProduct(params *AddWeightForBulkProductParams) (*AddWeightForBulkProductResponse, error) {
+func (c FBS) AddWeightForBulkProduct(ctx context.Context, params *AddWeightForBulkProductParams) (*AddWeightForBulkProductResponse, error) {
 	url := "/v2/posting/fbs/product/change"
 
 	resp := &AddWeightForBulkProductResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2422,12 +2423,12 @@ type CancelSendingResponse struct {
 // You can't cancel presumably delivered orders.
 //
 // If `cancel_reason_id` parameter value is 402, fill the `cancel_reason_message` field.
-func (c FBS) CancelSending(params *CancelSendingParams) (*CancelSendingResponse, error) {
+func (c FBS) CancelSending(ctx context.Context, params *CancelSendingParams) (*CancelSendingResponse, error) {
 	url := "/v2/posting/fbs/product/cancel"
 
 	resp := &CancelSendingResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2492,12 +2493,12 @@ type ListShipmentInCertificateResultProduct struct {
 }
 
 // Returns a list of shipments in the certificate by certificate identifier
-func (c FBS) ListShipmentInCertificate(params *ListShipmentInCertificateParams) (*ListShipmentInCertificateResponse, error) {
+func (c FBS) ListShipmentInCertificate(ctx context.Context, params *ListShipmentInCertificateParams) (*ListShipmentInCertificateResponse, error) {
 	url := "/v2/posting/fbs/act/get-postings"
 
 	resp := &ListShipmentInCertificateResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2529,12 +2530,12 @@ type SpecifyNumberOfBoxesResult struct {
 }
 
 // Method for passing the number of boxes for multi-box shipments when working under the rFBS Aggregator scheme (using the Ozon partner delivery)
-func (c FBS) SpecifyNumberOfBoxes(params *SpecifyNumberOfBoxesParams) (*SpecifyNumberOfBoxesResponse, error) {
+func (c FBS) SpecifyNumberOfBoxes(ctx context.Context, params *SpecifyNumberOfBoxesParams) (*SpecifyNumberOfBoxesResponse, error) {
 	url := "/v3/posting/multiboxqty/set"
 
 	resp := &SpecifyNumberOfBoxesResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2600,12 +2601,12 @@ type StatusOfActResponseResult struct {
 // the method returns status of generating an acceptance and transfer certificate and a waybill.
 //
 // If you are connected to EDC, the method returns status of generating a waybill only
-func (c FBS) StatusOfAct(params *StatusOfActParams) (*StatusOfActResponse, error) {
+func (c FBS) StatusOfAct(ctx context.Context, params *StatusOfActParams) (*StatusOfActResponse, error) {
 	url := "/v2/posting/fbs/act/check-status"
 
 	resp := &StatusOfActResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2656,12 +2657,12 @@ type ETGBCustomDeclarationsResultETGB struct {
 }
 
 // Method for getting Elektronik Ticaret Gümrük Beyannamesi (ETGB) customs declarations for sellers from Turkey
-func (c FBS) ETGBCustomsDeclarations(params *ETGBCustomsDeclarationsParams) (*ETGBCustomsDeclarationsResponse, error) {
+func (c FBS) ETGBCustomsDeclarations(ctx context.Context, params *ETGBCustomsDeclarationsParams) (*ETGBCustomsDeclarationsResponse, error) {
 	url := "/v1/posting/global/etgb"
 
 	resp := &ETGBCustomsDeclarationsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2689,12 +2690,12 @@ type BarcodeFromProductShipmentResponse struct {
 }
 
 // Method for getting a barcode to show at a pick-up point or sorting center during the shipment
-func (c FBS) BarcodeFromProductShipment(params *BarcodeFromProductShipmentParams) (*BarcodeFromProductShipmentResponse, error) {
+func (c FBS) BarcodeFromProductShipment(ctx context.Context, params *BarcodeFromProductShipmentParams) (*BarcodeFromProductShipmentResponse, error) {
 	url := "/v2/posting/fbs/act/get-barcode"
 
 	resp := &BarcodeFromProductShipmentResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, map[string]string{
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, map[string]string{
 		"Content-Type": "image/png",
 	})
 	if err != nil {
@@ -2718,12 +2719,12 @@ type BarcodeValueFromProductShipmentResponse struct {
 }
 
 // Use this method to get the barcode from the /v2/posting/fbs/act/get-barcode response in text format.
-func (c FBS) BarcodeValueFromProductShipment(params *BarcodeValueFromProductShipmentParams) (*BarcodeValueFromProductShipmentResponse, error) {
+func (c FBS) BarcodeValueFromProductShipment(ctx context.Context, params *BarcodeValueFromProductShipmentParams) (*BarcodeValueFromProductShipmentResponse, error) {
 	url := "/v2/posting/fbs/act/get-barcode/text"
 
 	resp := &BarcodeValueFromProductShipmentResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2756,12 +2757,12 @@ type GetActPDFResponse struct {
 // If you are not connected to electronic document circulation (EDC), the method returns an acceptance and transfer certificate and a waybill.
 //
 // If you are connected to EDC, the method returns a waybill only.
-func (c FBS) GetActPDF(params *GetActPDFParams) (*GetActPDFResponse, error) {
+func (c FBS) GetActPDF(ctx context.Context, params *GetActPDFParams) (*GetActPDFResponse, error) {
 	url := "/v2/posting/fbs/act/get-pdf"
 
 	resp := &GetActPDFResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, map[string]string{
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, map[string]string{
 		"Content-Type": "application/pdf",
 	})
 	if err != nil {

--- a/ozon/fbs_test.go
+++ b/ozon/fbs_test.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -167,7 +168,8 @@ func TestListUnprocessedShipments(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().ListUnprocessedShipments(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().ListUnprocessedShipments(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -278,7 +280,8 @@ func TestGetFBSShipmentsList(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().GetFBSShipmentsList(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().GetFBSShipmentsList(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -339,7 +342,8 @@ func TestPackOrder(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().PackOrder(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().PackOrder(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -416,7 +420,8 @@ func TestValidateLabelingCodes(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().ValidateLabelingCodes(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().ValidateLabelingCodes(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -529,7 +534,8 @@ func TestGetShipmentDataByBarcode(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().GetShipmentDataByBarcode(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().GetShipmentDataByBarcode(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -642,7 +648,8 @@ func TestGetShipmentDataByIdentifier(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().GetShipmentDataByIdentifier(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().GetShipmentDataByIdentifier(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -714,7 +721,8 @@ func TestAddTrackingNumbers(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().AddTrackingNumbers(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().AddTrackingNumbers(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -807,7 +815,8 @@ func TestListOfShipmentCertificates(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().ListOfShipmentCertificates(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().ListOfShipmentCertificates(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -868,7 +877,8 @@ func TestSignShipmentCertificate(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().SignShipmentCertificate(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().SignShipmentCertificate(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -943,22 +953,26 @@ func TestChangeStatusTo(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		deliveringResp, err := c.FBS().ChangeStatusToDelivering(test.params)
+		deliveringctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		deliveringResp, err := c.FBS().ChangeStatusToDelivering(deliveringctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
 
-		lastMileResp, err := c.FBS().ChangeStatusToLastMile(test.params)
+		lastMilectx, _ := context.WithTimeout(context.Background(), testTimeout)
+		lastMileResp, err := c.FBS().ChangeStatusToLastMile(lastMilectx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
 
-		deliveredResp, err := c.FBS().ChangeStatusToDelivered(test.params)
+		deliveredctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		deliveredResp, err := c.FBS().ChangeStatusToDelivered(deliveredctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
 
-		sendBySellerResp, err := c.FBS().ChangeStatusToSendBySeller(test.params)
+		sendBySellerctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		sendBySellerResp, err := c.FBS().ChangeStatusToSendBySeller(sendBySellerctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1005,7 +1019,8 @@ func TestPassShipmentToShipping(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().PassShipmentToShipping(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().PassShipmentToShipping(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1053,7 +1068,8 @@ func TestCancelShipment(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().CancelShipment(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().CancelShipment(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1103,7 +1119,8 @@ func TestCreateAct(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().CreateAct(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().CreateAct(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1152,7 +1169,8 @@ func TestGetLabeling(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().GetLabeling(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().GetLabeling(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1205,7 +1223,8 @@ func TestPrintLabeling(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().PrintLabeling(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().PrintLabeling(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1259,7 +1278,8 @@ func TestCreateTaskForGeneratingLabel(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().CreateTaskForGeneratingLabel(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().CreateTaskForGeneratingLabel(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1319,7 +1339,8 @@ func TestGetDropOffPointRestrictions(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().GetDropOffPointRestrictions(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().GetDropOffPointRestrictions(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1379,7 +1400,8 @@ func TestCheckProductItemsData(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().CheckproductItemsData(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().CheckproductItemsData(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1442,7 +1464,8 @@ func TestGetProductItemsCheckStatuses(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().GetProductItemsCheckStatuses(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().GetProductItemsCheckStatuses(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1510,7 +1533,8 @@ func TestRescheduleShipmentDeliveryDate(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().RescheduleShipmentDeliveryDate(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().RescheduleShipmentDeliveryDate(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1561,7 +1585,8 @@ func TestDateAvailableForDeliverySchedule(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().DateAvailableForDeliverySchedule(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().DateAvailableForDeliverySchedule(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1620,7 +1645,8 @@ func TestListManufactoruingCountries(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().ListManufacturingCountries(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().ListManufacturingCountries(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1680,7 +1706,8 @@ func TestSetManufacturingCountry(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().SetManufacturingCountry(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().SetManufacturingCountry(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1747,7 +1774,8 @@ func TestPartialPackOrder(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().PartialPackOrder(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().PartialPackOrder(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1819,7 +1847,8 @@ func TestAvailableFreightsList(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().AvailableFreightsList(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().AvailableFreightsList(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1866,7 +1895,8 @@ func TestGenerateAct(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().GenerateAct(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().GenerateAct(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1915,7 +1945,8 @@ func TestGetDigitalAct(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().GetDigitalAct(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().GetDigitalAct(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1969,7 +2000,8 @@ func TestPackageUnitLabels(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().PackageUnitLabel(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().PackageUnitLabel(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -2021,7 +2053,8 @@ func TestOpenDisputeOverShipment(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().OpenDisputeOverShipment(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().OpenDisputeOverShipment(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -2088,7 +2121,8 @@ func TestShipmentCancellationReasons(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().ShipmentCancellationReasons(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().ShipmentCancellationReasons(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -2183,7 +2217,8 @@ func TestShipmentsCancellationReasons(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().ShipmentsCancellationReasons()
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().ShipmentsCancellationReasons(ctx)
 		if err != nil {
 			t.Error(err)
 		}
@@ -2244,7 +2279,8 @@ func TestAddWeightForBulkProduct(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().AddWeightForBulkProduct(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().AddWeightForBulkProduct(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -2304,7 +2340,8 @@ func TestCancelSending(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().CancelSending(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().CancelSending(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -2369,7 +2406,8 @@ func TestListShipmentInCertificate(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().ListShipmentInCertificate(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().ListShipmentInCertificate(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -2417,7 +2455,8 @@ func TestSpecifyNumberOfBoxes(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().SpecifyNumberOfBoxes(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().SpecifyNumberOfBoxes(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -2465,7 +2504,8 @@ func TestStatusOfAct(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().StatusOfAct(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().StatusOfAct(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -2523,7 +2563,8 @@ func TestETGBCustomsDeclarations(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().ETGBCustomsDeclarations(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().ETGBCustomsDeclarations(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -2571,7 +2612,8 @@ func TestBarcodeFromProductShipment(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().BarcodeFromProductShipment(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().BarcodeFromProductShipment(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -2629,7 +2671,8 @@ func TestBarcodeValueFromProductShipment(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().BarcodeValueFromProductShipment(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().BarcodeValueFromProductShipment(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -2683,7 +2726,8 @@ func TestGetActPDF(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.FBS().GetActPDF(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.FBS().GetActPDF(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}

--- a/ozon/finance.go
+++ b/ozon/finance.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -151,12 +152,12 @@ type ReportOnSoldProductsResultRow struct {
 // Returns information on products sold and returned within a month. Canceled or non-purchased products are not included.
 //
 // Report is returned no later than the 5th day of the next month
-func (c Finance) ReportOnSoldProducts(params *ReportOnSoldProductsParams) (*ReportOnSoldProductsResponse, error) {
+func (c Finance) ReportOnSoldProducts(ctx context.Context, params *ReportOnSoldProductsParams) (*ReportOnSoldProductsResponse, error) {
 	url := "/v1/finance/realization"
 
 	resp := &ReportOnSoldProductsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -241,12 +242,12 @@ type GetTotalTransactionsSumResult struct {
 }
 
 // Returns total sums for transactions for specified period
-func (c Finance) GetTotalTransactionsSum(params *GetTotalTransactionsSumParams) (*GetTotalTransactionsSumResponse, error) {
+func (c Finance) GetTotalTransactionsSum(ctx context.Context, params *GetTotalTransactionsSumParams) (*GetTotalTransactionsSumResponse, error) {
 	url := "/v3/finance/transaction/totals"
 
 	resp := &GetTotalTransactionsSumResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -390,12 +391,12 @@ type ListTransactionsResultOperationService struct {
 // Returns detailed information on all accruals. The maximum period for which you can get information in one request is 1 month.
 //
 // If you don't specify the posting_number in request, the response contains all shipments for the specified period or shipments of a certain type
-func (c Finance) ListTransactions(params *ListTransactionsParams) (*ListTransactionsResponse, error) {
+func (c Finance) ListTransactions(ctx context.Context, params *ListTransactionsParams) (*ListTransactionsResponse, error) {
 	url := "/v3/finance/transaction/list"
 
 	resp := &ListTransactionsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/ozon/finance_test.go
+++ b/ozon/finance_test.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -90,7 +91,8 @@ func TestReportOnSoldProducts(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Finance().ReportOnSoldProducts(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Finance().ReportOnSoldProducts(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -158,7 +160,8 @@ func TestGetTotalTransactionsSum(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Finance().GetTotalTransactionsSum(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Finance().GetTotalTransactionsSum(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -246,7 +249,8 @@ func TestListTransactions(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Finance().ListTransactions(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Finance().ListTransactions(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}

--- a/ozon/invoices.go
+++ b/ozon/invoices.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -42,12 +43,12 @@ type CreateUpdateProformaLinkResponse struct {
 }
 
 // Create or edit proforma invoice link for VAT refund to Turkey sellers
-func (c Invoices) CreateUpdate(params *CreateUpdateProformaLinkParams) (*CreateUpdateProformaLinkResponse, error) {
+func (c Invoices) CreateUpdate(ctx context.Context, params *CreateUpdateProformaLinkParams) (*CreateUpdateProformaLinkResponse, error) {
 	url := "/v1/invoice/create-or-update"
 
 	resp := &CreateUpdateProformaLinkResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -74,12 +75,12 @@ type GetProformaLinkResult struct {
 }
 
 // Get a proforma invoice link
-func (c Invoices) Get(params *GetProformaLinkParams) (*GetProformaLinkResponse, error) {
+func (c Invoices) Get(ctx context.Context, params *GetProformaLinkParams) (*GetProformaLinkResponse, error) {
 	url := "/v1/invoice/get"
 
 	resp := &GetProformaLinkResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -100,12 +101,12 @@ type DeleteProformaLinkResponse struct {
 	Result bool `json:"result"`
 }
 
-func (c Invoices) Delete(params *DeleteProformaLinkParams) (*DeleteProformaLinkResponse, error) {
+func (c Invoices) Delete(ctx context.Context, params *DeleteProformaLinkParams) (*DeleteProformaLinkResponse, error) {
 	url := "/v1/invoice/delete"
 
 	resp := &DeleteProformaLinkResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/ozon/invoices_test.go
+++ b/ozon/invoices_test.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -48,7 +49,8 @@ func TestCreateUpdateProformaLink(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Invoices().CreateUpdate(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Invoices().CreateUpdate(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -96,7 +98,8 @@ func TestGetProformaLink(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Invoices().Get(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Invoices().Get(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -142,7 +145,8 @@ func TestDeleteProformaLink(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Invoices().Delete(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Invoices().Delete(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}

--- a/ozon/ozon.go
+++ b/ozon/ozon.go
@@ -105,8 +105,8 @@ func (c Client) Strategies() *Strategies {
 	return c.strategies
 }
 
-func NewClient(clientId, apiKey string) *Client {
-	coreClient := core.NewClient(DefaultAPIBaseUrl, map[string]string{
+func NewClient(httpClient core.HttpClient, clientId, apiKey string) *Client {
+	coreClient := core.NewClient(httpClient, DefaultAPIBaseUrl, map[string]string{
 		"Client-Id": clientId,
 		"Api-Key":   apiKey,
 	})

--- a/ozon/polygons.go
+++ b/ozon/polygons.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 
 	core "github.com/diphantxm/ozon-api-client"
@@ -25,12 +26,12 @@ type CreateDeliveryPolygonResponse struct {
 // You can link a polygon to the delivery method.
 //
 // Create a polygon getting its coordinates on https://geojson.io: mark at least 3 points on the map and connect them
-func (c Polygons) CreateDelivery(params *CreateDeliveryPolygonParams) (*CreateDeliveryPolygonResponse, error) {
+func (c Polygons) CreateDelivery(ctx context.Context, params *CreateDeliveryPolygonParams) (*CreateDeliveryPolygonResponse, error) {
 	url := "/v1/polygon/create"
 
 	resp := &CreateDeliveryPolygonResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -71,12 +72,12 @@ type LinkDeliveryMethodToPolygonResponse struct {
 }
 
 // Link delivery method to a delivery polygon
-func (c Polygons) Link(params *LinkDeliveryMethodToPolygonParams) (*LinkDeliveryMethodToPolygonResponse, error) {
+func (c Polygons) Link(ctx context.Context, params *LinkDeliveryMethodToPolygonParams) (*LinkDeliveryMethodToPolygonResponse, error) {
 	url := "/v1/polygon/bind"
 
 	resp := &LinkDeliveryMethodToPolygonResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -95,12 +96,12 @@ type DeletePolygonResponse struct {
 }
 
 // Delete polygon
-func (c Polygons) Delete(params *DeletePolygonParams) (*DeletePolygonResponse, error) {
+func (c Polygons) Delete(ctx context.Context, params *DeletePolygonParams) (*DeletePolygonResponse, error) {
 	url := "/v1/polygon/delete"
 
 	resp := &DeletePolygonResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/ozon/polygons_test.go
+++ b/ozon/polygons_test.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -42,7 +43,8 @@ func TestCreateDeliveryPolygon(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Polygons().CreateDelivery(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Polygons().CreateDelivery(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -96,7 +98,8 @@ func TestLinkDeliveryMethodToPolygon(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Polygons().Link(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Polygons().Link(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -140,7 +143,8 @@ func TestDeletePolygon(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Polygons().Delete(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Polygons().Delete(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}

--- a/ozon/products.go
+++ b/ozon/products.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -82,12 +83,12 @@ type GetStocksInfoResultItemStock struct {
 // * how many items are available,
 //
 // * how many are reserved by customers.
-func (c Products) GetStocksInfo(params *GetStocksInfoParams) (*GetStocksInfoResponse, error) {
+func (c Products) GetStocksInfo(ctx context.Context, params *GetStocksInfoParams) (*GetStocksInfoResponse, error) {
 	url := "/v3/product/info/stocks"
 
 	resp := &GetStocksInfoResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -419,12 +420,12 @@ type GetProductDetailsResponseItemError struct {
 }
 
 // Get product details
-func (c Products) GetProductDetails(params *GetProductDetailsParams) (*GetProductDetailsResponse, error) {
+func (c Products) GetProductDetails(ctx context.Context, params *GetProductDetailsParams) (*GetProductDetailsResponse, error) {
 	url := "/v2/product/info"
 
 	resp := &GetProductDetailsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -484,12 +485,12 @@ type UpdateStocksResultError struct {
 // With one request you can change the availability for 100 products. You can send up to 80 requests in a minute.
 //
 // Availability can only be set after the product status has been changed to processed.
-func (c Products) UpdateStocks(params *UpdateStocksParams) (*UpdateStocksResponse, error) {
+func (c Products) UpdateStocks(ctx context.Context, params *UpdateStocksParams) (*UpdateStocksResponse, error) {
 	url := "/v1/product/import/stocks"
 
 	resp := &UpdateStocksResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -558,12 +559,12 @@ type UpdateQuantityStockProductsResultError struct {
 // Availability can only be set after the product status has been changed to processed.
 //
 // Bulky products stock can only be updated in the warehouses for bulky products.
-func (c Products) UpdateQuantityStockProducts(params *UpdateQuantityStockProductsParams) (*UpdateQuantityStockProductsResponse, error) {
+func (c Products) UpdateQuantityStockProducts(ctx context.Context, params *UpdateQuantityStockProductsParams) (*UpdateQuantityStockProductsResponse, error) {
 	url := "/v2/products/stocks"
 
 	resp := &UpdateQuantityStockProductsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -605,12 +606,12 @@ type StocksInSellersWarehouseResult struct {
 }
 
 // Get stocks in seller's warehouse
-func (c Products) StocksInSellersWarehouse(params *StocksInSellersWarehouseParams) (*StocksInSellersWarehouseResponse, error) {
+func (c Products) StocksInSellersWarehouse(ctx context.Context, params *StocksInSellersWarehouseParams) (*StocksInSellersWarehouseResponse, error) {
 	url := "/v1/product/info/stocks-by-warehouse/fbs"
 
 	resp := &StocksInSellersWarehouseResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -691,12 +692,12 @@ type UpdatePricesResultError struct {
 // To reset old_price or premium_price set these parameters to 0.
 //
 // A new price must differ from the old one by at least 5%.
-func (c Products) UpdatePrices(params *UpdatePricesParams) (*UpdatePricesResponse, error) {
+func (c Products) UpdatePrices(ctx context.Context, params *UpdatePricesParams) (*UpdatePricesResponse, error) {
 	url := "/v1/product/import/prices"
 
 	resp := &UpdatePricesResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -866,12 +867,12 @@ type CreateOrUpdateProductResult struct {
 }
 
 // This method allows you to create products and update their details
-func (c Products) CreateOrUpdateProduct(params *CreateOrUpdateProductParams) (*CreateOrUpdateProductResponse, error) {
+func (c Products) CreateOrUpdateProduct(ctx context.Context, params *CreateOrUpdateProductParams) (*CreateOrUpdateProductResponse, error) {
 	url := "/v2/product/import"
 
 	resp := &CreateOrUpdateProductResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -932,12 +933,12 @@ type GetListOfProductsResultItem struct {
 	ProductId int64 `json:"product_id"`
 }
 
-func (c Products) GetListOfProducts(params *GetListOfProductsParams) (*GetListOfProductsResponse, error) {
+func (c Products) GetListOfProducts(ctx context.Context, params *GetListOfProductsParams) (*GetListOfProductsResponse, error) {
 	url := "/v2/product/list"
 
 	resp := &GetListOfProductsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1015,12 +1016,12 @@ type GetProductsRatingBySKUProductGroupImproveAttr struct {
 }
 
 // Method for getting products' content rating and recommendations on how to increase it
-func (c Products) GetProductsRatingBySKU(params *GetProductsRatingBySKUParams) (*GetProductsRatingBySKUResponse, error) {
+func (c Products) GetProductsRatingBySKU(ctx context.Context, params *GetProductsRatingBySKUParams) (*GetProductsRatingBySKUResponse, error) {
 	url := "/v1/product/rating-by-sku"
 
 	resp := &GetProductsRatingBySKUResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1076,12 +1077,12 @@ type GetProductImportStatusResultItemError struct {
 }
 
 // Allows you to get the status of a product description page creation process
-func (c Products) GetProductImportStatus(params *GetProductImportStatusParams) (*GetProductImportStatusResponse, error) {
+func (c Products) GetProductImportStatus(ctx context.Context, params *GetProductImportStatusParams) (*GetProductImportStatusResponse, error) {
 	url := "/v1/product/import/info"
 
 	resp := &GetProductImportStatusResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1144,12 +1145,12 @@ type CreateProductByOzonIDResponse struct {
 // Creates a product by the specified Ozon ID. The number of products is unlimited.
 //
 // It's not possible to update products using Ozon ID
-func (c Products) CreateProductByOzonID(params *CreateProductByOzonIDParams) (*CreateProductByOzonIDResponse, error) {
+func (c Products) CreateProductByOzonID(ctx context.Context, params *CreateProductByOzonIDParams) (*CreateProductByOzonIDResponse, error) {
 	url := "/v1/product/import-by-sku"
 
 	resp := &CreateProductByOzonIDResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1233,12 +1234,12 @@ type ProductInfoResultPicture struct {
 // first get the details using `/v2/product/info` or `/v2/product/info/list` methods.
 // Using them you can get the current list of images and their order.
 // Copy the data from the images, images360, and color_image fields and make the necessary changes to it
-func (c Products) UpdateProductImages(params *UpdateProductImagesParams) (*ProductInfoResponse, error) {
+func (c Products) UpdateProductImages(ctx context.Context, params *UpdateProductImagesParams) (*ProductInfoResponse, error) {
 	url := "/v1/product/pictures/import"
 
 	resp := &ProductInfoResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1253,12 +1254,12 @@ type CheckImageUploadingStatusParams struct {
 }
 
 // Check products images uploading status
-func (c Products) CheckImageUploadingStatus(params *CheckImageUploadingStatusParams) (*ProductInfoResponse, error) {
+func (c Products) CheckImageUploadingStatus(ctx context.Context, params *CheckImageUploadingStatusParams) (*ProductInfoResponse, error) {
 	url := "/v1/product/pictures/info"
 
 	resp := &ProductInfoResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1295,12 +1296,12 @@ type ListProductsByIDsResult struct {
 // The request body must contain an array of identifiers of the same type. The response will contain an items array.
 //
 // For each shipment in the items array the fields match the ones recieved in the /v2/product/info method
-func (c Products) ListProductsByIDs(params *ListProductsByIDsParams) (*ListProductsByIDsResponse, error) {
+func (c Products) ListProductsByIDs(ctx context.Context, params *ListProductsByIDsParams) (*ListProductsByIDsResponse, error) {
 	url := "/v2/product/info/list"
 
 	resp := &ListProductsByIDsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1483,12 +1484,12 @@ type GetDescriptionOfProductResultPDF struct {
 }
 
 // Returns a product characteristics description by product identifier. You can search for the product by `offer_id` or `product_id`
-func (c Products) GetDescriptionOfProduct(params *GetDescriptionOfProductParams) (*GetDescriptionOfProductResponse, error) {
+func (c Products) GetDescriptionOfProduct(ctx context.Context, params *GetDescriptionOfProductParams) (*GetDescriptionOfProductResponse, error) {
 	url := "/v3/products/info/attributes"
 
 	resp := &GetDescriptionOfProductResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1527,12 +1528,12 @@ type GetProductDescriptionResult struct {
 }
 
 // Get product description
-func (c Products) GetProductDescription(params *GetProductDescriptionParams) (*GetProductDescriptionResponse, error) {
+func (c Products) GetProductDescription(ctx context.Context, params *GetProductDescriptionParams) (*GetProductDescriptionResponse, error) {
 	url := "/v1/product/info/description"
 
 	resp := &GetProductDescriptionResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1579,12 +1580,12 @@ type GetProductRangeLimitUploadQuota struct {
 //   - Products update limit: how many products you can update per day.
 //
 // If you have a product range limit and you exceed it, you won't be able to create new products
-func (c Products) GetProductRangeLimit() (*GetProductRangeLimitResponse, error) {
+func (c Products) GetProductRangeLimit(ctx context.Context) (*GetProductRangeLimitResponse, error) {
 	url := "/v4/product/info/limit"
 
 	resp := &GetProductRangeLimitResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, &struct{}{}, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, &struct{}{}, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1626,12 +1627,12 @@ type ChangeProductIDsError struct {
 // Method for changing the offer_id linked to products. You can change multiple offer_id in this method.
 //
 // We recommend transmitting up to 250 values in an array
-func (c Products) ChangeProductIDs(params *ChangeProductIDsParams) (*ChangeProductIDsResponse, error) {
+func (c Products) ChangeProductIDs(ctx context.Context, params *ChangeProductIDsParams) (*ChangeProductIDsResponse, error) {
 	url := "/v1/product/update/offer-id"
 
 	resp := &ChangeProductIDsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1653,12 +1654,12 @@ type ArchiveProductResponse struct {
 }
 
 // Archive product
-func (c Products) ArchiveProduct(params *ArchiveProductParams) (*ArchiveProductResponse, error) {
+func (c Products) ArchiveProduct(ctx context.Context, params *ArchiveProductParams) (*ArchiveProductResponse, error) {
 	url := "/v1/product/archive"
 
 	resp := &ArchiveProductResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1670,12 +1671,12 @@ func (c Products) ArchiveProduct(params *ArchiveProductParams) (*ArchiveProductR
 // Warning: Since June 14, 2023 the method is disabled.
 //
 // Unarchive product
-func (c Products) UnarchiveProduct(params *ArchiveProductParams) (*ArchiveProductResponse, error) {
+func (c Products) UnarchiveProduct(ctx context.Context, params *ArchiveProductParams) (*ArchiveProductResponse, error) {
 	url := "/v1/product/unarchive"
 
 	resp := &ArchiveProductResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1715,12 +1716,12 @@ type RemoveProductWithoutSKUStatus struct {
 // Remove a product without an SKU from the archive
 //
 // You can pass up to 500 identifiers in one request
-func (c Products) RemoveProductWithoutSKU(params *RemoveProductWithoutSKUParams) (*RemoveProductWithoutSKUResponse, error) {
+func (c Products) RemoveProductWithoutSKU(ctx context.Context, params *RemoveProductWithoutSKUParams) (*RemoveProductWithoutSKUResponse, error) {
 	url := "/v2/products/delete"
 
 	resp := &RemoveProductWithoutSKUResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1776,12 +1777,12 @@ type ListGeoRestrictionsRestriction struct {
 }
 
 // Get a list of geo-restrictions for services
-func (c Products) ListGeoRestrictions(params *ListGeoRestrictionsParams) (*ListGeoRestrictionsResponse, error) {
+func (c Products) ListGeoRestrictions(ctx context.Context, params *ListGeoRestrictionsParams) (*ListGeoRestrictionsResponse, error) {
 	url := "/v1/products/geo-restrictions-catalog-by-filter"
 
 	resp := &ListGeoRestrictionsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1811,12 +1812,12 @@ type UploadActivationCodesResult struct {
 }
 
 // Upload activation codes when you upload service or digital products. Activation code is associated with the digital product card
-func (c Products) UploadActivationCodes(params *UploadActivationCodesParams) (*UploadActivationCodesResponse, error) {
+func (c Products) UploadActivationCodes(ctx context.Context, params *UploadActivationCodesParams) (*UploadActivationCodesResponse, error) {
 	url := "/v1/product/upload_digital_codes"
 
 	resp := &UploadActivationCodesResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1846,12 +1847,12 @@ type StatusOfUploadingActivationCodesResult struct {
 }
 
 // Get status of uploading activation codes task for services and digital products
-func (c Products) StatusOfUploadingActivationCodes(params *StatusOfUploadingActivationCodesParams) (*StatusOfUploadingActivationCodesResponse, error) {
+func (c Products) StatusOfUploadingActivationCodes(ctx context.Context, params *StatusOfUploadingActivationCodesParams) (*StatusOfUploadingActivationCodesResponse, error) {
 	url := "/v1/product/upload_digital_codes/info"
 
 	resp := &StatusOfUploadingActivationCodesResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2105,12 +2106,12 @@ type GetProductPriceInfoResultItemPriceIndexesSelfMarketplace struct {
 }
 
 // You can specify up to 1000 products in the request
-func (c Products) GetProductPriceInfo(params *GetProductPriceInfoParams) (*GetProductPriceInfoResponse, error) {
+func (c Products) GetProductPriceInfo(ctx context.Context, params *GetProductPriceInfoParams) (*GetProductPriceInfoResponse, error) {
 	url := "/v4/product/info/prices"
 
 	resp := &GetProductPriceInfoResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2181,12 +2182,12 @@ type GetMarkdownInfoItem struct {
 //
 // A method for getting information about the condition and defects of a markdown product by its SKU.
 // The method also returns the SKU of the main product
-func (c Products) GetMarkdownInfo(params *GetMarkdownInfoParams) (*GetMarkdownInfoResponse, error) {
+func (c Products) GetMarkdownInfo(ctx context.Context, params *GetMarkdownInfoParams) (*GetMarkdownInfoResponse, error) {
 	url := "/v1/product/info/discounted"
 
 	resp := &GetMarkdownInfoResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2211,12 +2212,12 @@ type SetDiscountOnMarkdownProductResponse struct {
 }
 
 // A method for setting the discount percentage on markdown products sold under the FBS scheme
-func (c Products) SetDiscountOnMarkdownProduct(params *SetDiscountOnMarkdownProductParams) (*SetDiscountOnMarkdownProductResponse, error) {
+func (c Products) SetDiscountOnMarkdownProduct(ctx context.Context, params *SetDiscountOnMarkdownProductParams) (*SetDiscountOnMarkdownProductResponse, error) {
 	url := "/v1/product/update/discount"
 
 	resp := &SetDiscountOnMarkdownProductResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2246,12 +2247,12 @@ type NumberOfSubsToProductAvailabilityResult struct {
 }
 
 // You can pass multiple products in a request
-func (c Products) NumberOfSubsToProductAvailability(params *NumberOfSubsToProductAvailabilityParams) (*NumberOfSubsToProductAvailabilityResponse, error) {
+func (c Products) NumberOfSubsToProductAvailability(ctx context.Context, params *NumberOfSubsToProductAvailabilityParams) (*NumberOfSubsToProductAvailabilityResponse, error) {
 	url := "/v1/product/info/subscription"
 
 	resp := &NumberOfSubsToProductAvailabilityResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2302,12 +2303,12 @@ type UpdateCharacteristicsResponse struct {
 	TaskId int64 `json:"task_id"`
 }
 
-func (c Products) UpdateCharacteristics(params *UpdateCharacteristicsParams) (*UpdateCharacteristicsResponse, error) {
+func (c Products) UpdateCharacteristics(ctx context.Context, params *UpdateCharacteristicsParams) (*UpdateCharacteristicsResponse, error) {
 	url := "/v1/product/attributes/update"
 
 	resp := &UpdateCharacteristicsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/ozon/products_test.go
+++ b/ozon/products_test.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -70,7 +71,8 @@ func TestGetStocksInfo(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Products().GetStocksInfo(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Products().GetStocksInfo(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -267,7 +269,8 @@ func TestGetProductDetails(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Products().GetProductDetails(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Products().GetProductDetails(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -341,7 +344,8 @@ func TestUpdateStocks(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Products().UpdateStocks(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Products().UpdateStocks(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -410,7 +414,8 @@ func TestStocksInSellersWarehouse(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Products().StocksInSellersWarehouse(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Products().StocksInSellersWarehouse(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -484,7 +489,8 @@ func TestUpdatePrices(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Products().UpdatePrices(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Products().UpdatePrices(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -556,7 +562,8 @@ func TestUpdateQuantityStockProducts(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Products().UpdateQuantityStockProducts(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Products().UpdateQuantityStockProducts(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -690,7 +697,8 @@ func TestCreateOrUpdateProduct(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Products().CreateOrUpdateProduct(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Products().CreateOrUpdateProduct(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -757,7 +765,8 @@ func TestGetListOfProducts(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Products().GetListOfProducts(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Products().GetListOfProducts(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1003,7 +1012,8 @@ func TestGetProductsRatingBySKU(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Products().GetProductsRatingBySKU(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Products().GetProductsRatingBySKU(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1070,7 +1080,8 @@ func TestGetProductImportStatus(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Products().GetProductImportStatus(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Products().GetProductImportStatus(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1141,7 +1152,8 @@ func TestCreateProductByOzonID(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Products().CreateProductByOzonID(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Products().CreateProductByOzonID(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1209,7 +1221,8 @@ func TestUpdateProductImages(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Products().UpdateProductImages(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Products().UpdateProductImages(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1277,7 +1290,8 @@ func TestCheckImageUploadingStatus(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Products().CheckImageUploadingStatus(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Products().CheckImageUploadingStatus(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1472,7 +1486,8 @@ func TestListProductsByIDs(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Products().ListProductsByIDs(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Products().ListProductsByIDs(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1706,7 +1721,8 @@ func TestGetDescriptionOfProduct(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Products().GetDescriptionOfProduct(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Products().GetDescriptionOfProduct(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1764,7 +1780,8 @@ func TestGetProductDescription(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Products().GetProductDescription(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Products().GetProductDescription(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1827,7 +1844,8 @@ func TestGetProductRangeLimit(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Products().GetProductRangeLimit()
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Products().GetProductRangeLimit(ctx)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1883,7 +1901,8 @@ func TestChangeProductIDs(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Products().ChangeProductIDs(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Products().ChangeProductIDs(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1929,7 +1948,8 @@ func TestArchiveProduct(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Products().ArchiveProduct(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Products().ArchiveProduct(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1975,7 +1995,8 @@ func TestUnarchiveProduct(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Products().UnarchiveProduct(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Products().UnarchiveProduct(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -2031,7 +2052,8 @@ func TestRemoveProductWithoutSKU(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Products().RemoveProductWithoutSKU(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Products().RemoveProductWithoutSKU(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -2108,7 +2130,8 @@ func TestListGeoRestrictions(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Products().ListGeoRestrictions(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Products().ListGeoRestrictions(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -2157,7 +2180,8 @@ func TestUploadActivationCodes(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Products().UploadActivationCodes(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Products().UploadActivationCodes(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -2205,7 +2229,8 @@ func TestStatusOfUploadingActivationCodes(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Products().StatusOfUploadingActivationCodes(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Products().StatusOfUploadingActivationCodes(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -2318,7 +2343,8 @@ func TestGetProductPriceInfo(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Products().GetProductPriceInfo(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Products().GetProductPriceInfo(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -2380,7 +2406,8 @@ func TestGetMarkdownInfo(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Products().GetMarkdownInfo(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Products().GetMarkdownInfo(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -2435,7 +2462,8 @@ func TestSetDiscountOnMarkdownProduct(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Products().SetDiscountOnMarkdownProduct(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Products().SetDiscountOnMarkdownProduct(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -2486,7 +2514,8 @@ func TestNumberOfSubsToProductAvailability(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Products().NumberOfSubsToProductAvailability(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Products().NumberOfSubsToProductAvailability(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -2560,7 +2589,8 @@ func TestUpdateCharacteristics(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Products().UpdateCharacteristics(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Products().UpdateCharacteristics(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}

--- a/ozon/promotions.go
+++ b/ozon/promotions.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -73,12 +74,12 @@ type GetAvailablePromotionsResult struct {
 }
 
 // A method for getting a list of promotions that you can participate in
-func (c Promotions) GetAvailablePromotions() (*GetAvailablePromotionsResponse, error) {
+func (c Promotions) GetAvailablePromotions(ctx context.Context) (*GetAvailablePromotionsResponse, error) {
 	url := "/v1/actions"
 
 	resp := &GetAvailablePromotionsResponse{}
 
-	response, err := c.client.Request(http.MethodGet, url, nil, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodGet, url, nil, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -130,12 +131,12 @@ type AddProductToPromotionResultRejected struct {
 }
 
 // A method for adding products to an available promotion
-func (c Promotions) AddToPromotion(params *AddProductToPromotionParams) (*AddProductToPromotionResponse, error) {
+func (c Promotions) AddToPromotion(ctx context.Context, params *AddProductToPromotionParams) (*AddProductToPromotionResponse, error) {
 	url := "/v1/actions/products/activate"
 
 	resp := &AddProductToPromotionResponse{}
 
-	response, err := c.client.Request(http.MethodGet, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodGet, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -195,12 +196,12 @@ type PromotionProduct struct {
 }
 
 // A method for getting a list of products that can participate in the promotion by the promotion identifier
-func (c Promotions) ProductsAvailableForPromotion(params *ProductsAvailableForPromotionParams) (*ProductsAvailableForPromotionResponse, error) {
+func (c Promotions) ProductsAvailableForPromotion(ctx context.Context, params *ProductsAvailableForPromotionParams) (*ProductsAvailableForPromotionResponse, error) {
 	url := "/v1/actions/candidates"
 
 	resp := &ProductsAvailableForPromotionResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -236,12 +237,12 @@ type ProductsInPromotionResult struct {
 }
 
 // A method for getting the list of products participating in the promotion by its identifier
-func (c Promotions) ProductsInPromotion(params *ProductsInPromotionParams) (*ProductsInPromotionResponse, error) {
+func (c Promotions) ProductsInPromotion(ctx context.Context, params *ProductsInPromotionParams) (*ProductsInPromotionResponse, error) {
 	url := "/v1/actions/products"
 
 	resp := &ProductsInPromotionResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -282,12 +283,12 @@ type RemoveProductFromPromotionResultRejected struct {
 }
 
 // A method for removing products from the promotion
-func (c Promotions) RemoveProduct(params *RemoveProductFromPromotionParams) (*RemoveProductFromPromotionResponse, error) {
+func (c Promotions) RemoveProduct(ctx context.Context, params *RemoveProductFromPromotionParams) (*RemoveProductFromPromotionResponse, error) {
 	url := "/v1/actions/products/deactivate"
 
 	resp := &RemoveProductFromPromotionResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -332,12 +333,12 @@ type ListHotSalePromotionsResult struct {
 }
 
 // List of available Hot Sale promotions
-func (c Promotions) ListHotSalePromotions() (*ListHotSalePromotionsResponse, error) {
+func (c Promotions) ListHotSalePromotions(ctx context.Context) (*ListHotSalePromotionsResponse, error) {
 	url := "/v1/actions/hotsales/list"
 
 	resp := &ListHotSalePromotionsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, nil, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, nil, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -396,12 +397,12 @@ type ProductsAvailableForHotSalePromotionResultProduct struct {
 }
 
 // Method for getting a list of products that can participate or are already participating in the Hot Sale promotion
-func (c Promotions) ProductsAvailableForHotSalePromotion(params *ProductsAvailableForHotSalePromotionParams) (*ProductsAvailableForHotSalePromotionResponse, error) {
+func (c Promotions) ProductsAvailableForHotSalePromotion(ctx context.Context, params *ProductsAvailableForHotSalePromotionParams) (*ProductsAvailableForHotSalePromotionResponse, error) {
 	url := "/v1/actions/hotsales/products"
 
 	resp := &ProductsAvailableForHotSalePromotionResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -449,12 +450,12 @@ type ProductsToHotSaleResultRejected struct {
 	Reason string `json:"reason"`
 }
 
-func (c Promotions) AddProductsToHotSale(params *AddProductsToHotSaleParams) (*ProductsToHotSaleResponse, error) {
+func (c Promotions) AddProductsToHotSale(ctx context.Context, params *AddProductsToHotSaleParams) (*ProductsToHotSaleResponse, error) {
 	url := "/v1/actions/hotsales/activate"
 
 	resp := &ProductsToHotSaleResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -472,12 +473,12 @@ type RemoveProductsToHotSaleParams struct {
 }
 
 // Remove product from the Hot Sale promotion
-func (c Promotions) RemoveProductsToHotSale(params *RemoveProductsToHotSaleParams) (*ProductsToHotSaleResponse, error) {
+func (c Promotions) RemoveProductsToHotSale(ctx context.Context, params *RemoveProductsToHotSaleParams) (*ProductsToHotSaleResponse, error) {
 	url := "/v1/actions/hotsales/activate"
 
 	resp := &ProductsToHotSaleResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -612,12 +613,12 @@ type ListDiscountRequestsResult struct {
 }
 
 // Method for getting a list of products that customers want to buy with discount
-func (c Promotions) ListDiscountRequests(params *ListDiscountRequestsParams) (*ListDiscountRequestsResponse, error) {
+func (c Promotions) ListDiscountRequests(ctx context.Context, params *ListDiscountRequestsParams) (*ListDiscountRequestsResponse, error) {
 	url := "/v1/actions/discounts-task/list"
 
 	resp := &ListDiscountRequestsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -677,12 +678,12 @@ type DiscountRequestResultFailDetail struct {
 // You can approve applications in statuses:
 //   - NEW — new
 //   - SEEN — viewed
-func (c Promotions) ApproveDiscountRequest(params *DiscountRequestParams) (*DiscountRequestResponse, error) {
+func (c Promotions) ApproveDiscountRequest(ctx context.Context, params *DiscountRequestParams) (*DiscountRequestResponse, error) {
 	url := "/v1/actions/discounts-task/approve"
 
 	resp := &DiscountRequestResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -694,12 +695,12 @@ func (c Promotions) ApproveDiscountRequest(params *DiscountRequestParams) (*Disc
 // You can decline applications in statuses:
 //   - NEW—new
 //   - SEEN—viewed
-func (c Promotions) DeclineDiscountRequest(params *DiscountRequestParams) (*DiscountRequestResponse, error) {
+func (c Promotions) DeclineDiscountRequest(ctx context.Context, params *DiscountRequestParams) (*DiscountRequestResponse, error) {
 	url := "/v1/actions/discounts-task/decline"
 
 	resp := &DiscountRequestResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/ozon/promotions_test.go
+++ b/ozon/promotions_test.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -56,7 +57,8 @@ func TestGetAvailablePromotions(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Promotions().GetAvailablePromotions()
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Promotions().GetAvailablePromotions(ctx)
 		if err != nil {
 			t.Error(err)
 		}
@@ -125,7 +127,8 @@ func TestAddToPromotion(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Promotions().AddToPromotion(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Promotions().AddToPromotion(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -201,7 +204,8 @@ func TestProductsAvailableForPromotion(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Promotions().ProductsAvailableForPromotion(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Promotions().ProductsAvailableForPromotion(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -262,7 +266,8 @@ func TestProductsInPromotion(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Promotions().ProductsInPromotion(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Promotions().ProductsInPromotion(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -314,7 +319,8 @@ func TestRemoveProduct(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Promotions().RemoveProduct(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Promotions().RemoveProduct(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -373,7 +379,8 @@ func TestListHotSalePromotions(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Promotions().ListHotSalePromotions()
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Promotions().ListHotSalePromotions(ctx)
 		if err != nil {
 			t.Error(err)
 		}
@@ -434,7 +441,8 @@ func TestProductsAvailableForHotSalePromotion(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Promotions().ProductsAvailableForHotSalePromotion(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Promotions().ProductsAvailableForHotSalePromotion(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -494,7 +502,8 @@ func TestAddProductsToHotSale(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Promotions().AddProductsToHotSale(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Promotions().AddProductsToHotSale(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -548,7 +557,8 @@ func TestRemoveProductsToHotSale(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Promotions().RemoveProductsToHotSale(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Promotions().RemoveProductsToHotSale(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -634,7 +644,8 @@ func TestListDiscountRequests(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Promotions().ListDiscountRequests(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Promotions().ListDiscountRequests(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -661,9 +672,9 @@ func TestApproveDiscountRequest(t *testing.T) {
 			&DiscountRequestParams{
 				Tasks: []DiscountRequestTask{
 					{
-						Id: 123,
-						ApprovedPrice: 11,
-						SellerComment: "string",
+						Id:                  123,
+						ApprovedPrice:       11,
+						SellerComment:       "string",
 						ApprovedQuantityMin: 1,
 						ApprovedQuantityMax: 2,
 					},
@@ -697,7 +708,8 @@ func TestApproveDiscountRequest(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Promotions().ApproveDiscountRequest(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Promotions().ApproveDiscountRequest(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -724,9 +736,9 @@ func TestDeclineDiscountRequest(t *testing.T) {
 			&DiscountRequestParams{
 				Tasks: []DiscountRequestTask{
 					{
-						Id: 123,
-						ApprovedPrice: 11,
-						SellerComment: "string",
+						Id:                  123,
+						ApprovedPrice:       11,
+						SellerComment:       "string",
 						ApprovedQuantityMin: 1,
 						ApprovedQuantityMax: 2,
 					},
@@ -760,7 +772,8 @@ func TestDeclineDiscountRequest(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Promotions().DeclineDiscountRequest(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Promotions().DeclineDiscountRequest(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}

--- a/ozon/rating.go
+++ b/ozon/rating.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -90,12 +91,12 @@ type GetCurrentSellerRatingInfoGroupItemChange struct {
 	Meaning string `json:"meaning"`
 }
 
-func (c Rating) GetCurrentSellerRatingInfo() (*GetCurrentSellerRatingInfoResponse, error) {
+func (c Rating) GetCurrentSellerRatingInfo(ctx context.Context) (*GetCurrentSellerRatingInfoResponse, error) {
 	url := "/v1/rating/summary"
 
 	resp := &GetCurrentSellerRatingInfoResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, nil, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, nil, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -189,12 +190,12 @@ type GetSellerRatingInfoPeriodRatingValueStatus struct {
 	Warning bool `json:"warning"`
 }
 
-func (c Rating) GetSellerRatingInfoForPeriod(params *GetSellerRatingInfoForPeriodParams) (*GetSellerRatingInfoPeriodResponse, error) {
+func (c Rating) GetSellerRatingInfoForPeriod(ctx context.Context, params *GetSellerRatingInfoForPeriodParams) (*GetSellerRatingInfoPeriodResponse, error) {
 	url := "/v1/rating/history"
 
 	resp := &GetSellerRatingInfoPeriodResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/ozon/rating_test.go
+++ b/ozon/rating_test.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -58,7 +59,8 @@ func TestGetCurrentRatingInfo(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Rating().GetCurrentSellerRatingInfo()
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Rating().GetCurrentSellerRatingInfo(ctx)
 		if err != nil {
 			t.Error(err)
 		}
@@ -146,7 +148,8 @@ func TestGetRatingInfoForPeriod(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Rating().GetSellerRatingInfoForPeriod(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Rating().GetSellerRatingInfoForPeriod(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}

--- a/ozon/reports.go
+++ b/ozon/reports.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -83,12 +84,12 @@ type GetReportsListResultReport struct {
 }
 
 // Returns the list of reports that have been generated before
-func (c Reports) GetList(params *GetReportsListParams) (*GetReportsListResponse, error) {
+func (c Reports) GetList(ctx context.Context, params *GetReportsListParams) (*GetReportsListResponse, error) {
 	url := "/v1/report/list"
 
 	resp := &GetReportsListResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -143,12 +144,12 @@ type GetReportDetailResult struct {
 }
 
 // Returns information about a created report by its identifier
-func (c Reports) GetReportDetails(params *GetReportDetailsParams) (*GetReportDetailsResponse, error) {
+func (c Reports) GetReportDetails(ctx context.Context, params *GetReportDetailsParams) (*GetReportDetailsResponse, error) {
 	url := "/v1/report/info"
 
 	resp := &GetReportDetailsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -392,12 +393,12 @@ type GetFinancialResultResultDetailOthersItem struct {
 }
 
 // Returns information about a created report by its identifier
-func (c Reports) GetFinancial(params *GetFinancialReportParams) (*GetFinancialReportResponse, error) {
+func (c Reports) GetFinancial(ctx context.Context, params *GetFinancialReportParams) (*GetFinancialReportResponse, error) {
 	url := "/v1/finance/cash-flow-statement/list"
 
 	resp := &GetFinancialReportResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -440,12 +441,12 @@ type GetProductsReportResult struct {
 }
 
 // Method for getting a report with products data. For example, Ozon ID, number of products, prices, status
-func (c Reports) GetProducts(params *GetProductsReportParams) (*GetProductsReportResponse, error) {
+func (c Reports) GetProducts(ctx context.Context, params *GetProductsReportParams) (*GetProductsReportResponse, error) {
 	url := "/v1/report/products/create"
 
 	resp := &GetProductsReportResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -475,12 +476,12 @@ type GetStocksReportResult struct {
 }
 
 // Report with information about the number of available and reserved products in stock
-func (c Reports) GetStocks(params *GetStocksReportParams) (*GetStocksReportResponse, error) {
+func (c Reports) GetStocks(ctx context.Context, params *GetStocksReportParams) (*GetStocksReportResponse, error) {
 	url := "/v1/report/stock/create"
 
 	resp := &GetStocksReportResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -520,12 +521,12 @@ type GetProductsMovementReportResult struct {
 //   - products in transit between the fulfillment centers,
 //   - products in delivery,
 //   - products to be sold
-func (c Reports) GetProductsMovement(params *GetProductsMovementReportParams) (*GetProductsMovementReportResponse, error) {
+func (c Reports) GetProductsMovement(ctx context.Context, params *GetProductsMovementReportParams) (*GetProductsMovementReportResponse, error) {
 	url := "/v1/report/products/movement/create"
 
 	resp := &GetProductsMovementReportResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -571,12 +572,12 @@ type GetReturnReportResult struct {
 // The report contains information about returned products that were accepted from the customer, ready for pickup, or delivered to the seller.
 //
 // The method is only suitable for orders shipped from the seller's warehouse
-func (c Reports) GetReturns(params *GetReturnsReportParams) (*GetReturnsReportResponse, error) {
+func (c Reports) GetReturns(ctx context.Context, params *GetReturnsReportParams) (*GetReturnsReportResponse, error) {
 	url := "/v1/report/returns/create"
 
 	resp := &GetReturnsReportResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -646,12 +647,12 @@ type GetShipmentReportResult struct {
 //   - shipment numbers
 //   - shipment costs
 //   - shipments contents
-func (c Reports) GetShipment(params *GetShipmentReportParams) (*GetShipmentReportResponse, error) {
+func (c Reports) GetShipment(ctx context.Context, params *GetShipmentReportParams) (*GetShipmentReportResponse, error) {
 	url := "/v1/report/postings/create"
 
 	resp := &GetShipmentReportResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -671,12 +672,12 @@ type IssueOnDiscountedProductsResponse struct {
 // For example, Ozon can discount a product due to damage when delivering.
 //
 // Returns report identifier. To get the report, send the identifier in the request body of a method `/v1/report/discounted/info`
-func (c Reports) IssueOnDiscountedProducts() (*IssueOnDiscountedProductsResponse, error) {
+func (c Reports) IssueOnDiscountedProducts(ctx context.Context) (*IssueOnDiscountedProductsResponse, error) {
 	url := "/v1/report/discounted/create"
 
 	resp := &IssueOnDiscountedProductsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, nil, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, nil, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -716,12 +717,12 @@ type ReportonDiscountedProductsReport struct {
 }
 
 // By report identifier, returns information about the report generated earlier
-func (c Reports) ReportOnDiscountedProducts(params *ReportOnDiscountedProductsParams) (*ReportOnDiscountedProductsResponse, error) {
+func (c Reports) ReportOnDiscountedProducts(ctx context.Context, params *ReportOnDiscountedProductsParams) (*ReportOnDiscountedProductsResponse, error) {
 	url := "/v1/report/discounted/info"
 
 	resp := &ReportOnDiscountedProductsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, nil, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, nil, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -731,12 +732,12 @@ func (c Reports) ReportOnDiscountedProducts(params *ReportOnDiscountedProductsPa
 }
 
 // By report identifier, returns information about the report generated earlier
-func (c Reports) ListReportsOnDiscountedProducts() (*ReportOnDiscountedProductsResponse, error) {
+func (c Reports) ListReportsOnDiscountedProducts(ctx context.Context) (*ReportOnDiscountedProductsResponse, error) {
 	url := "/v1/report/discounted/list"
 
 	resp := &ReportOnDiscountedProductsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, nil, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, nil, resp, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/ozon/reports_test.go
+++ b/ozon/reports_test.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -69,7 +70,8 @@ func TestGetList(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Reports().GetList(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Reports().GetList(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -130,7 +132,8 @@ func TestGetReportDetails(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Reports().GetReportDetails(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Reports().GetReportDetails(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -274,7 +277,8 @@ func TestGetFinancialReport(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Reports().GetFinancial(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Reports().GetFinancial(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -328,7 +332,8 @@ func TestGetProductsReport(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Reports().GetProducts(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Reports().GetProducts(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -380,7 +385,8 @@ func TestGetStocksReport(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Reports().GetStocks(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Reports().GetStocks(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -435,7 +441,8 @@ func TestGetProductsMovementReport(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Reports().GetProductsMovement(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Reports().GetProductsMovement(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -491,7 +498,8 @@ func TestGetReturnsReport(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Reports().GetReturns(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Reports().GetReturns(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -549,7 +557,8 @@ func TestGetShipmentReport(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Reports().GetShipment(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Reports().GetShipment(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -596,7 +605,8 @@ func TestIssueOnDiscountedProducts(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Reports().IssueOnDiscountedProducts()
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Reports().IssueOnDiscountedProducts(ctx)
 		if err != nil {
 			t.Error(err)
 		}
@@ -653,7 +663,8 @@ func TestReportOnDiscountedProducts(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Reports().ReportOnDiscountedProducts(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Reports().ReportOnDiscountedProducts(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -701,7 +712,8 @@ func TestListReportsOnDiscountedProducts(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Reports().ListReportsOnDiscountedProducts()
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Reports().ListReportsOnDiscountedProducts(ctx)
 		if err != nil {
 			t.Error(err)
 		}

--- a/ozon/returns.go
+++ b/ozon/returns.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -78,12 +79,12 @@ type GetFBOReturnsReturn struct {
 }
 
 // Method for getting information on returned products that are sold from the Ozon warehouse
-func (c Returns) GetFBOReturns(params *GetFBOReturnsParams) (*GetFBOReturnsResponse, error) {
+func (c Returns) GetFBOReturns(ctx context.Context, params *GetFBOReturnsParams) (*GetFBOReturnsResponse, error) {
 	url := "/v3/returns/company/fbo"
 
 	resp := &GetFBOReturnsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -247,12 +248,12 @@ type GetFBSReturnResultReturn struct {
 }
 
 // Method for getting information on returned products that are sold from the seller's warehouse
-func (c Returns) GetFBSReturns(params *GetFBSReturnsParams) (*GetFBSReturnsResponse, error) {
+func (c Returns) GetFBSReturns(ctx context.Context, params *GetFBSReturnsParams) (*GetFBSReturnsResponse, error) {
 	url := "/v3/returns/company/fbs"
 
 	resp := &GetFBSReturnsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/ozon/returns_test.go
+++ b/ozon/returns_test.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -61,7 +62,8 @@ func TestGetFBOReturns(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Returns().GetFBOReturns(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Returns().GetFBOReturns(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -159,7 +161,8 @@ func TestGetFBSReturns(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Returns().GetFBSReturns(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Returns().GetFBSReturns(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}

--- a/ozon/strategies.go
+++ b/ozon/strategies.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 
 	core "github.com/diphantxm/ozon-api-client"
@@ -38,12 +39,12 @@ type ListCompetitorsCompetitor struct {
 }
 
 // Method for getting a list of competitors—sellers with similar products in other online stores and marketplaces
-func (c Strategies) ListCompetitors(params *ListCompetitorsParams) (*ListCompetitorsResponse, error) {
+func (c Strategies) ListCompetitors(ctx context.Context, params *ListCompetitorsParams) (*ListCompetitorsResponse, error) {
 	url := "/v1/pricing-strategy/competitors/list"
 
 	resp := &ListCompetitorsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -97,12 +98,12 @@ type ListStrategiesStrategy struct {
 	Enabled bool `json:"enabled"`
 }
 
-func (c Strategies) List(params *ListStrategiesParams) (*ListStrategiesResponse, error) {
+func (c Strategies) List(ctx context.Context, params *ListStrategiesParams) (*ListStrategiesResponse, error) {
 	url := "/v1/pricing-strategy/list"
 
 	resp := &ListStrategiesResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -140,12 +141,12 @@ type CreateStrategyResult struct {
 	StrategyId string `json:"strategy_id"`
 }
 
-func (c Strategies) Create(params *CreateStrategyParams) (*CreateStrategyResponse, error) {
+func (c Strategies) Create(ctx context.Context, params *CreateStrategyParams) (*CreateStrategyResponse, error) {
 	url := "/v1/pricing-strategy/create"
 
 	resp := &CreateStrategyResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -183,12 +184,12 @@ type InfoStrategyResult struct {
 	UpdateType StrategyUpdateType `json:"update_type"`
 }
 
-func (c Strategies) Info(params *InfoStrategyParams) (*InfoStrategyResponse, error) {
+func (c Strategies) Info(ctx context.Context, params *InfoStrategyParams) (*InfoStrategyResponse, error) {
 	url := "/v1/pricing-strategy/info"
 
 	resp := &InfoStrategyResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -212,12 +213,12 @@ type UpdateStrategyResponse struct {
 	core.CommonResponse
 }
 
-func (c Strategies) Update(params *UpdateStrategyParams) (*UpdateStrategyResponse, error) {
+func (c Strategies) Update(ctx context.Context, params *UpdateStrategyParams) (*UpdateStrategyResponse, error) {
 	url := "/v1/pricing-strategy/update"
 
 	resp := &UpdateStrategyResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -260,12 +261,12 @@ type AddProductsToStrategyResultError struct {
 	ProductId int64 `json:"product_id"`
 }
 
-func (c Strategies) AddProducts(params *AddProductsToStrategyParams) (*AddProductsToStrategyResponse, error) {
+func (c Strategies) AddProducts(ctx context.Context, params *AddProductsToStrategyParams) (*AddProductsToStrategyResponse, error) {
 	url := "/v1/pricing-strategy/products/add"
 
 	resp := &AddProductsToStrategyResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -299,12 +300,12 @@ type GetStrategiesByProductIdsResultProductInfo struct {
 	StrategyId string `json:"strategy_id"`
 }
 
-func (c Strategies) GetByProductIds(params *GetStrategiesByProductIdsParams) (*GetStrategiesByProductIdsResponse, error) {
+func (c Strategies) GetByProductIds(ctx context.Context, params *GetStrategiesByProductIdsParams) (*GetStrategiesByProductIdsResponse, error) {
 	url := "/v1/pricing-strategy/strategy-ids-by-product-ids"
 
 	resp := &GetStrategiesByProductIdsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -330,12 +331,12 @@ type ListProductsInStrategyResult struct {
 	ProductId []string `json:"product_id"`
 }
 
-func (c Strategies) ListProducts(params *ListProductsInStrategyParams) (*ListProductsInStrategyResponse, error) {
+func (c Strategies) ListProducts(ctx context.Context, params *ListProductsInStrategyParams) (*ListProductsInStrategyResponse, error) {
 	url := "/v1/pricing-strategy/products/list"
 
 	resp := &ListProductsInStrategyResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -376,12 +377,12 @@ type GetCompetitorPriceResult struct {
 	StrategyCompetitorProductURL string `json:"strategy_competitor_product_url"`
 }
 
-func (c Strategies) GetCompetitorPrice(params *GetCompetitorPriceParams) (*GetCompetitorPriceResponse, error) {
+func (c Strategies) GetCompetitorPrice(ctx context.Context, params *GetCompetitorPriceParams) (*GetCompetitorPriceResponse, error) {
 	url := "/v1/pricing-strategy/product/info"
 
 	resp := &GetCompetitorPriceResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -407,12 +408,12 @@ type RemoveProductsFromStrategyResult struct {
 	FailedProductCount int32 `json:"failed_product_count"`
 }
 
-func (c Strategies) RemoveProducts(params *RemoveProductsFromStrategyParams) (*RemoveProductsFromStrategyResponse, error) {
+func (c Strategies) RemoveProducts(ctx context.Context, params *RemoveProductsFromStrategyParams) (*RemoveProductsFromStrategyResponse, error) {
 	url := "/v1/pricing-strategy/products/delete"
 
 	resp := &RemoveProductsFromStrategyResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -433,12 +434,12 @@ type ChangeStrategyStatusResponse struct {
 	core.CommonResponse
 }
 
-func (c Strategies) ChangeStatus(params *ChangeStrategyStatusParams) (*ChangeStrategyStatusResponse, error) {
+func (c Strategies) ChangeStatus(ctx context.Context, params *ChangeStrategyStatusParams) (*ChangeStrategyStatusResponse, error) {
 	url := "/v1/pricing-strategy/status"
 
 	resp := &ChangeStrategyStatusResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -456,12 +457,12 @@ type RemoveStrategyResponse struct {
 	core.CommonResponse
 }
 
-func (c Strategies) Remove(params *RemoveStrategyParams) (*RemoveStrategyResponse, error) {
+func (c Strategies) Remove(ctx context.Context, params *RemoveStrategyParams) (*RemoveStrategyResponse, error) {
 	url := "/v1/pricing-strategy/delete"
 
 	resp := &RemoveStrategyResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, params, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, params, resp, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/ozon/strategies_test.go
+++ b/ozon/strategies_test.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -49,7 +50,8 @@ func TestListCompetitors(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Strategies().ListCompetitors(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Strategies().ListCompetitors(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -108,7 +110,8 @@ func TestListStrategies(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Strategies().List(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Strategies().List(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -174,7 +177,8 @@ func TestCreateStrategy(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Strategies().Create(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Strategies().Create(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -235,7 +239,8 @@ func TestInfoStrategy(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Strategies().Info(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Strategies().Info(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -302,7 +307,8 @@ func TestUpdateStrategy(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Strategies().Update(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Strategies().Update(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -351,7 +357,8 @@ func TestAddProductsToStrategy(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Strategies().AddProducts(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Strategies().AddProducts(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -404,7 +411,8 @@ func TestGetStrategiesByProductIds(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Strategies().GetByProductIds(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Strategies().GetByProductIds(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -466,7 +474,8 @@ func TestListProductsInStrategy(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Strategies().ListProducts(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Strategies().ListProducts(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -519,7 +528,8 @@ func TestGetCompetitorPrice(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Strategies().GetCompetitorPrice(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Strategies().GetCompetitorPrice(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -567,7 +577,8 @@ func TestRemoveProductsFromStrategy(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Strategies().RemoveProducts(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Strategies().RemoveProducts(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -612,7 +623,8 @@ func TestChangeStrategyStatus(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Strategies().ChangeStatus(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Strategies().ChangeStatus(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -656,7 +668,8 @@ func TestRemoveStrategy(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Strategies().Remove(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Strategies().Remove(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}

--- a/ozon/warehouses.go
+++ b/ozon/warehouses.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -85,12 +86,12 @@ type GetListOfWarehousesResultFirstMile struct {
 }
 
 // You do not need to specify any parameters in the request. Your company will be identified by the Warehouses ID
-func (c Warehouses) GetListOfWarehouses() (*GetListOfWarehousesResponse, error) {
+func (c Warehouses) GetListOfWarehouses(ctx context.Context) (*GetListOfWarehousesResponse, error) {
 	url := "/v1/warehouse/list"
 
 	resp := &GetListOfWarehousesResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, nil, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, nil, resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -175,12 +176,12 @@ type GetListOfDeliveryMethodsResult struct {
 }
 
 // This methods allows you to get list of all delivery methods that can be applied for this warehouse
-func (c Warehouses) GetListOfDeliveryMethods(params *GetListOfDeliveryMethodsParams) (*GetListOfDeliveryMethodsResponse, error) {
+func (c Warehouses) GetListOfDeliveryMethods(ctx context.Context, params *GetListOfDeliveryMethodsParams) (*GetListOfDeliveryMethodsResponse, error) {
 	url := "/v1/delivery-method/list"
 
 	resp := &GetListOfDeliveryMethodsResponse{}
 
-	response, err := c.client.Request(http.MethodPost, url, nil, resp, nil)
+	response, err := c.client.Request(ctx, http.MethodPost, url, nil, resp, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/ozon/warehouses_test.go
+++ b/ozon/warehouses_test.go
@@ -1,6 +1,7 @@
 package ozon
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -58,7 +59,8 @@ func TestGetListOfWarehouses(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Warehouses().GetListOfWarehouses()
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Warehouses().GetListOfWarehouses(ctx)
 		if err != nil {
 			t.Error(err)
 		}
@@ -133,7 +135,8 @@ func TestGetListOfDeliveryMethods(t *testing.T) {
 	for _, test := range tests {
 		c := NewMockClient(core.NewMockHttpHandler(test.statusCode, test.response, test.headers))
 
-		resp, err := c.Warehouses().GetListOfDeliveryMethods(test.params)
+		ctx, _ := context.WithTimeout(context.Background(), testTimeout)
+		resp, err := c.Warehouses().GetListOfDeliveryMethods(ctx, test.params)
 		if err != nil {
 			t.Error(err)
 		}


### PR DESCRIPTION
Context is needed to limit time of execution of a method. Previously, context was passed to structure and it was stored inside structure which is a bad practice. Now we need to pass context to function, which is a best practice