### PR TITLE
Update May 23, 2024

### DIFF
--- a/ozon/fbs.go
+++ b/ozon/fbs.go
@@ -1672,15 +1672,25 @@ type CreateTaskForGeneratingLabelResponse struct {
 }
 
 type CreateTaskForGeneratingLabelResult struct {
+	Tasks []CreateTaskForGeneratingLabelTask `json:"tasks"`
+}
+
+type CreateTaskForGeneratingLabelTask struct {
 	// Task identifier for labeling generation
 	TaskId int64 `json:"task_id"`
+
+	// Type of label generation task:
+	//
+	// 	big_label — for a regular label,
+	// 	small_label — for a small label
+	TaskType string `json:"task_type"`
 }
 
 // Method for creating a task for asynchronous labeling generation.
 //
 // To get labels created as a result of the method, use the /v1/posting/fbs/package-label/get method
 func (c FBS) CreateTaskForGeneratingLabel(ctx context.Context, params *CreateTaskForGeneratingLabelParams) (*CreateTaskForGeneratingLabelResponse, error) {
-	url := "/v1/posting/fbs/package-label/create"
+	url := "/v2/posting/fbs/package-label/create"
 
 	resp := &CreateTaskForGeneratingLabelResponse{}
 

--- a/ozon/fbs_test.go
+++ b/ozon/fbs_test.go
@@ -1278,7 +1278,16 @@ func TestCreateTaskForGeneratingLabel(t *testing.T) {
 			},
 			`{
 				"result": {
-				  "task_id": 5819327210249
+				  "tasks": [
+					{
+					  "task_id": 5819327210248,
+					  "task_type": "big_label"
+					},
+					{
+					  "task_id": 5819327210249,
+					  "task_type": "small_label"
+					}
+				  ]
 				}
 			}`,
 		},
@@ -1310,7 +1319,7 @@ func TestCreateTaskForGeneratingLabel(t *testing.T) {
 			t.Errorf("got wrong status code: got: %d, expected: %d", resp.StatusCode, test.statusCode)
 		}
 		if resp.StatusCode == http.StatusOK {
-			if resp.Result.TaskId == 0 {
+			if len(resp.Result.Tasks) != 0 && resp.Result.Tasks[0].TaskId == 0 {
 				t.Errorf("Task id cannot be 0")
 			}
 		}


### PR DESCRIPTION
`/v2/posting/fbs/package-label/create` : Added a new version of the method for creating a task to generate labels.

`/v1/posting/fbs/package-label/create` : Method is deprecated and will be disabled. We'll give you one month's notice. Switch to the new version [/v2/posting/fbs/package-label/create](#operation/PostingAPI_CreateLabelBatchV2).