### PR TITLE
Update May 24, 2024

### DIFF
--- a/ozon/common.go
+++ b/ozon/common.go
@@ -723,7 +723,7 @@ const (
 	TransactionItemAdForSupplierLogistic TransactionOperationService = "ItemAdvertisementForSupplierLogistic"
 
 	// product placement service
-	TransactionServiceStorageItem TransactionOperationService = "MarketplaceServiceStorageItem"
+	TransactionServiceStorageItem TransactionOperationService = "OperationMarketplaceServiceStorage"
 
 	// products promotion
 	TransactionMarketingActionCost TransactionOperationService = "MarketplaceMarketingActionCostItem"

--- a/ozon/fbs.go
+++ b/ozon/fbs.go
@@ -452,6 +452,8 @@ type FinancialDataProduct struct {
 	CommissionsCurrencyCode string `json:"commissions_currency_code"`
 
 	// Services
+	//
+	// Deprecated: The parameter is outdated. To get information on accruals, use the `ListTransactions` method
 	ItemServices MarketplaceServices `json:"item_services"`
 
 	// Currency of your prices. It matches the currency set in the personal account settings

--- a/ozon/products.go
+++ b/ozon/products.go
@@ -151,7 +151,7 @@ type ProductDetails struct {
 	// SKU of the product that is sold from the seller's warehouse (FBS and rFBS)
 	FBSSKU int64 `json:"fbs_sku,omitempty"`
 
-	// Document generation task number
+	// Product identifier
 	Id int64 `json:"id"`
 
 	// An array of links to images. The images in the array are arranged in the order of their arrangement on the site. If the `primary_image` parameter is not specified, the first image in the list is the main one for the product
@@ -2378,8 +2378,10 @@ type GetRelatedSKUsError struct {
 	Message string `json:"message"`
 }
 
-// You can pass any SKU in the request, even a deleted one.
+// Method for getting a single SKU based on the old SKU FBS and SKU FBO identifiers.
 // The response will contain all SKUs related to the passed ones.
+//
+// The method can handle any SKU, even hidden or deleted.
 //
 // In one request, you can pass up to 200 SKUs.
 func (c Products) GetRelatedSKUs(ctx context.Context, params *GetRelatedSKUsParams) (*GetRelatedSKUsResponse, error) {

--- a/ozon/returns.go
+++ b/ozon/returns.go
@@ -187,7 +187,7 @@ type GetFBSReturnResultReturn struct {
 	// ID of the warehouse the product is being transported to
 	PlaceId int64 `json:"place_id"`
 
-	// Name of the warehouse the product is being transported to
+	// Intermediate return point
 	MovingToPlaceName string `json:"moving_to_place_name"`
 
 	// Delivery cost


### PR DESCRIPTION
`/v3/finance/transaction/list`: Replaced `Market place Service Storage Item` with `Operation Market place Service Storage` in the `operations.services` response parameter.

`/v1/product/related-sku/get`: Updated the method description.

`/v2/product/info/list`: Updated the `items.id ` parameter description in the method response.

`/v3/returns/company/fbs`: Updated the `returns.moving_to_place_name` parameter description in the method response.

`/v2/posting/fbo/get`, `/v2/posting/fbo/list`, `/v3/posting/fbs/unfulfilled/list`, `/v3/posting/fbs/get`, `/v3/posting/fbs/list`: Marked the `postings.financial_data.products.item_services` and `postings.financial_data.posting_services` parameters as outdated in the method response.