### PR TITLE
Change variable type for list of chats

### DIFF
--- a/ozon/chats.go
+++ b/ozon/chats.go
@@ -2,6 +2,7 @@ package ozon
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"time"
 
@@ -53,10 +54,10 @@ type ListChatsChat struct {
 	Chat ListChatsChatData `json:"chat"`
 
 	// Identifier of the first unread chat message
-	FirstUnreadMessageId string `json:"first_unread_message_id"`
+	FirstUnreadMessageId json.Number `json:"first_unread_message_id"`
 
 	// Identifier of the last message in the chat
-	LastMessageId string `json:"last_message_id"`
+	LastMessageId json.Number `json:"last_message_id"`
 
 	// Number of unread messages in the chat
 	UnreadCount int64 `json:"unread_count"`

--- a/ozon/chats.go
+++ b/ozon/chats.go
@@ -2,7 +2,6 @@ package ozon
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"time"
 
@@ -54,10 +53,10 @@ type ListChatsChat struct {
 	Chat ListChatsChatData `json:"chat"`
 
 	// Identifier of the first unread chat message
-	FirstUnreadMessageId json.Number `json:"first_unread_message_id"`
+	FirstUnreadMessageId uint64 `json:"first_unread_message_id"`
 
 	// Identifier of the last message in the chat
-	LastMessageId json.Number `json:"last_message_id"`
+	LastMessageId uint64 `json:"last_message_id"`
 
 	// Number of unread messages in the chat
 	UnreadCount int64 `json:"unread_count"`

--- a/ozon/chats_test.go
+++ b/ozon/chats_test.go
@@ -38,8 +38,8 @@ func TestListChats(t *testing.T) {
 					  "chat_status": "Opened",
 					  "chat_type": "Seller_Support"
 					},
-					"first_unread_message_id": "3000000000118021931",
-					"last_message_id": "30000000001280042740",
+					"first_unread_message_id": 3000000000118021931,
+					"last_message_id": 30000000001280042740,
 					"unread_count": 1
 				  }
 				],

--- a/ozon/chats_test.go
+++ b/ozon/chats_test.go
@@ -39,7 +39,7 @@ func TestListChats(t *testing.T) {
 					  "chat_type": "Seller_Support"
 					},
 					"first_unread_message_id": 3000000000118021931,
-					"last_message_id": 30000000001280042740,
+					"last_message_id": 3000000000128004274,
 					"unread_count": 1
 				  }
 				],


### PR DESCRIPTION
The chats API at Ozon might have been updated days ago. Previously, the API returned the two variables, first_unread_message_id and last_message_id,  as the type of string. But now, the return values have been changed to the uint64 type, consistently 19-digit numbers. Moreover, the official documentation for these two variables has also been updated to reflect the uint64 type. Keeping them as strings causes deserialization issues and results in continuous errors. Therefore, they should be changed to the uint64 type.