### PR TITLE
Change the data structure of chat response according to the updates from Ozon

### DIFF
--- a/ozon/chats.go
+++ b/ozon/chats.go
@@ -2,6 +2,7 @@ package ozon
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"time"
 
@@ -53,10 +54,10 @@ type ListChatsChat struct {
 	Chat ListChatsChatData `json:"chat"`
 
 	// Identifier of the first unread chat message
-	FirstUnreadMessageId string `json:"first_unread_message_id"`
+	FirstUnreadMessageId json.Number `json:"first_unread_message_id"`
 
 	// Identifier of the last message in the chat
-	LastMessageId string `json:"last_message_id"`
+	LastMessageId json.Number `json:"last_message_id"`
 
 	// Number of unread messages in the chat
 	UnreadCount int64 `json:"unread_count"`

--- a/ozon/chats.go
+++ b/ozon/chats.go
@@ -39,27 +39,13 @@ type ListChatsResponse struct {
 	core.CommonResponse
 
 	// Chats data
-	Chats []ListChatsChat `json:"chats"`
+	Chats []ListChatsChatData `json:"chats"`
 
 	// Total number of chats
 	TotalChatsCount int64 `json:"total_chats_count"`
 
 	// Total number of unread messages
 	TotalUnreadCount int64 `json:"total_unread_count"`
-}
-
-type ListChatsChat struct {
-	// Chat data
-	Chat ListChatsChatData `json:"chat"`
-
-	// Identifier of the first unread chat message
-	FirstUnreadMessageId uint64 `json:"first_unread_message_id"`
-
-	// Identifier of the last message in the chat
-	LastMessageId uint64 `json:"last_message_id"`
-
-	// Number of unread messages in the chat
-	UnreadCount int64 `json:"unread_count"`
 }
 
 type ListChatsChatData struct {
@@ -79,6 +65,15 @@ type ListChatsChatData struct {
 
 	// Chat creation date
 	CreatedAt time.Time `json:"created_at"`
+
+	// Identifier of the first unread chat message
+	FirstUnreadMessageId uint64 `json:"first_unread_message_id"`
+
+	// Identifier of the last message in the chat
+	LastMessageId uint64 `json:"last_message_id"`
+
+	// Number of unread messages in the chat
+	UnreadCount int64 `json:"unread_count"`
 }
 
 // Returns information about chats by specified filters

--- a/ozon/chats.go
+++ b/ozon/chats.go
@@ -2,7 +2,6 @@ package ozon
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"time"
 
@@ -54,10 +53,10 @@ type ListChatsChat struct {
 	Chat ListChatsChatData `json:"chat"`
 
 	// Identifier of the first unread chat message
-	FirstUnreadMessageId json.Number `json:"first_unread_message_id"`
+	FirstUnreadMessageId uint64 `json:"first_unread_message_id"`
 
 	// Identifier of the last message in the chat
-	LastMessageId json.Number `json:"last_message_id"`
+	LastMessageId uint64 `json:"last_message_id"`
 
 	// Number of unread messages in the chat
 	UnreadCount int64 `json:"unread_count"`

--- a/ozon/chats_test.go
+++ b/ozon/chats_test.go
@@ -32,15 +32,13 @@ func TestListChats(t *testing.T) {
 			`{
 				"chats": [
 				  {
-					"chat": {
-					  "created_at": "2022-07-22T08:07:19.581Z",
-					  "chat_id": "5e767w03-b400-4y1b-a841-75319ca8a5c8",
-					  "chat_status": "Opened",
-					  "chat_type": "Seller_Support"
-					},
-					"first_unread_message_id": 3000000000118021931,
+					"chat_id": "5e767w03-b400-4y1b-a841-75319ca8a5c8",
+					"chat_status": "Opened",
+					"chat_type": "Seller_Support",
+					"created_at": "2022-07-22T08:07:19.581Z",
+					"unread_count": 1,
 					"last_message_id": 3000000000128004274,
-					"unread_count": 1
+					"first_unread_message_id": 3000000000118021931
 				  }
 				],
 				"total_chats_count": 25,
@@ -77,10 +75,10 @@ func TestListChats(t *testing.T) {
 
 		if resp.StatusCode == http.StatusOK {
 			if len(resp.Chats) > 0 {
-				if resp.Chats[0].Chat.ChatStatus == "" {
+				if resp.Chats[0].ChatStatus == "" {
 					t.Errorf("Chat status cannot be empty")
 				}
-				if resp.Chats[0].Chat.ChatType == "" {
+				if resp.Chats[0].ChatType == "" {
 					t.Errorf("Chat type cannot be empty")
 				}
 			}

--- a/ozon/chats_test.go
+++ b/ozon/chats_test.go
@@ -38,8 +38,8 @@ func TestListChats(t *testing.T) {
 					  "chat_status": "Opened",
 					  "chat_type": "Seller_Support"
 					},
-					"first_unread_message_id": "3000000000118021931",
-					"last_message_id": "30000000001280042740",
+					"first_unread_message_id": 3000000000118021931,
+					"last_message_id": 30000000001280042740,
 					"unread_count": 1
 				  }
 				],

--- a/ozon/chats_test.go
+++ b/ozon/chats_test.go
@@ -39,7 +39,7 @@ func TestListChats(t *testing.T) {
 					  "chat_type": "Seller_Support"
 					},
 					"first_unread_message_id": 3000000000118021931,
-					"last_message_id": 30000000001280042740,
+					"last_message_id": 3000000000128004274,
 					"unread_count": 1
 				  }
 				],


### PR DESCRIPTION
The example of a chat list on the Ozon API document was wrong.  
The real response data has an array of chats. And there are no embedded objects inside the array. Each chat object only has keys listed below. 
- chat_id
- chat_status
- chat_type
- created_at
- first_unread_message_id
- last_message_id
- unread_count. 

The real response looks like the image below.
![chat_response](https://github.com/user-attachments/assets/1788b6e8-e814-4cd3-b3fb-c9cf65f6d3c8)
